### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/178/369/421178369.geojson
+++ b/data/421/178/369/421178369.geojson
@@ -219,7 +219,8 @@
     "qs:woe_id":1564691,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:population":"quattroshapes",
     "wof:belongsto":[
@@ -241,6 +242,10 @@
     },
     "wof:country":"ZM",
     "wof:created":1459009180,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"74ae70c9aa3166338e98faa637741437",
     "wof:hierarchy":[
         {
@@ -252,7 +257,7 @@
         }
     ],
     "wof:id":421178369,
-    "wof:lastmodified":1566665960,
+    "wof:lastmodified":1582350184,
     "wof:name":"Chingola",
     "wof:parent_id":1108782363,
     "wof:placetype":"locality",

--- a/data/421/178/937/421178937.geojson
+++ b/data/421/178/937/421178937.geojson
@@ -566,6 +566,9 @@
     },
     "wof:country":"ZM",
     "wof:created":1459009198,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7411ea7f92060b757ba92bae1b474790",
     "wof:hierarchy":[
         {
@@ -577,7 +580,7 @@
         }
     ],
     "wof:id":421178937,
-    "wof:lastmodified":1566665960,
+    "wof:lastmodified":1582350184,
     "wof:name":"Lusaka",
     "wof:parent_id":1108782421,
     "wof:placetype":"locality",

--- a/data/856/325/59/85632559.geojson
+++ b/data/856/325/59/85632559.geojson
@@ -931,6 +931,11 @@
     },
     "wof:country":"ZM",
     "wof:country_alpha3":"ZMB",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"f8e389b6b3040d88444cec22442f759b",
     "wof:hierarchy":[
         {
@@ -945,7 +950,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665072,
+    "wof:lastmodified":1582350172,
     "wof:name":"Zambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/810/47/85681047.geojson
+++ b/data/856/810/47/85681047.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Luapula Province"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e674131cab5f9616bea0832465357262",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665072,
+    "wof:lastmodified":1582350171,
     "wof:name":"Luapula",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/55/85681055.geojson
+++ b/data/856/810/55/85681055.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Northern Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1afc316cf784ccc4c5e7e36a4ebe4cfc",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665070,
+    "wof:lastmodified":1582350170,
     "wof:name":"Northern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/59/85681059.geojson
+++ b/data/856/810/59/85681059.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Central Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b933ed243b8c7ebf08757d8e9f16e427",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665067,
+    "wof:lastmodified":1582350169,
     "wof:name":"Central",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/63/85681063.geojson
+++ b/data/856/810/63/85681063.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Copperbelt Province"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea25780dc2eb1a469adb27c7898dd2e3",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665070,
+    "wof:lastmodified":1582350171,
     "wof:name":"Copperbelt",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/65/85681065.geojson
+++ b/data/856/810/65/85681065.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Eastern Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c141dfea41bd34de8387c7524995c3",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665069,
+    "wof:lastmodified":1582350170,
     "wof:name":"Eastern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/73/85681073.geojson
+++ b/data/856/810/73/85681073.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Lusaka Province"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c17b2656368a2277ec0825bf87d93e75",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665067,
+    "wof:lastmodified":1582350169,
     "wof:name":"Lusaka",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/75/85681075.geojson
+++ b/data/856/810/75/85681075.geojson
@@ -288,6 +288,9 @@
         "wk:page":"North-Western Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6805234a9a32c014a997a20cfc461845",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665069,
+    "wof:lastmodified":1582350170,
     "wof:name":"North-Western",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/79/85681079.geojson
+++ b/data/856/810/79/85681079.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Southern Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea9614068012d0fb308f51d83bd82f63",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665070,
+    "wof:lastmodified":1582350171,
     "wof:name":"Southern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/83/85681083.geojson
+++ b/data/856/810/83/85681083.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Western Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0a98a844a69f11b9b2b5b0d0e49144f",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665071,
+    "wof:lastmodified":1582350171,
     "wof:name":"Western",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/87/85681087.geojson
+++ b/data/856/810/87/85681087.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Northern Province, Zambia"
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0137fecfb1e405abc21e76f9b5fa40f4",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566665068,
+    "wof:lastmodified":1582350169,
     "wof:name":"Muchinga",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/857/719/61/85771961.geojson
+++ b/data/857/719/61/85771961.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":241148
     },
     "wof:country":"ZM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6319189e3349572c2f85138769a8cf87",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566665067,
+    "wof:lastmodified":1582350168,
     "wof:name":"Kabwata",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/427/539/890427539.geojson
+++ b/data/890/427/539/890427539.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"ZM",
     "wof:created":1469051701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70f1d9da95493d94888c229a8c9e1a61",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890427539,
-    "wof:lastmodified":1566665962,
+    "wof:lastmodified":1582350184,
     "wof:name":"Siavonga",
     "wof:parent_id":85681079,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.