### PR TITLE
Update megacity records

### DIFF
--- a/data/421/178/937/421178937.geojson
+++ b/data/421/178/937/421178937.geojson
@@ -574,6 +574,7 @@
         "gn:id":909137,
         "gp:id":1569006,
         "loc:id":"n79075575",
+        "ne:id":1159150571,
         "qs_pg:id":314058,
         "wd:id":"Q3881",
         "wk:page":"Lusaka"
@@ -597,7 +598,8 @@
         }
     ],
     "wof:id":421178937,
-    "wof:lastmodified":1607983540,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Lusaka",
     "wof:parent_id":1108782421,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary