### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/110/878/248/7/1108782487.geojson
+++ b/data/110/878/248/7/1108782487.geojson
@@ -37,6 +37,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0632\u0627\u0628\u0648\u0643\u0627"
     ],
+    "name:avk_x_preferred":[
+        "Mazabuka"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u099c\u09be\u09ac\u09c1\u0995\u09be"
     ],
@@ -85,6 +88,9 @@
     "name:mrj_x_preferred":[
         "\u041c\u0430\u0437\u0430\u0431\u0443\u043a\u0430"
     ],
+    "name:nan_x_preferred":[
+        "Mazabuka Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Mazabuka District"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u624e\u5e03\u5361\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Mazabuka District"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -145,7 +154,7 @@
         }
     ],
     "wof:id":1108782487,
-    "wof:lastmodified":1636501927,
+    "wof:lastmodified":1690930102,
     "wof:name":"Mazabuka",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/114/190/694/3/1141906943.geojson
+++ b/data/114/190/694/3/1141906943.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_preferred":[
         "\u0634\u064a\u0646\u063a\u0648\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u064a\u0646\u062c\u0648\u0644\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Chingola"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09bf\u0982\u0997\u09cb\u09b2\u09be"
     ],
@@ -55,6 +61,9 @@
         "Chingola"
     ],
     "name:fra_x_preferred":[
+        "Chingola"
+    ],
+    "name:gle_x_preferred":[
         "Chingola"
     ],
     "name:heb_x_preferred":[
@@ -108,7 +117,13 @@
     "name:spa_x_preferred":[
         "Chingola"
     ],
+    "name:swa_x_preferred":[
+        "Chingola"
+    ],
     "name:swe_x_preferred":[
+        "Chingola"
+    ],
+    "name:tum_x_preferred":[
         "Chingola"
     ],
     "name:tur_x_preferred":[
@@ -120,6 +135,9 @@
     "name:urd_x_preferred":[
         "\u0686\u0646\u06af\u0648\u0644\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Chingola"
+    ],
     "name:vie_x_preferred":[
         "Chingola"
     ],
@@ -128,6 +146,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6b3d\u6208\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Chingola"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -248,7 +269,7 @@
         }
     ],
     "wof:id":1141906943,
-    "wof:lastmodified":1636501948,
+    "wof:lastmodified":1690930119,
     "wof:name":"Chingola",
     "wof:parent_id":1108782365,
     "wof:placetype":"locality",

--- a/data/421/166/477/421166477.geojson
+++ b/data/421/166/477/421166477.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0641\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0641\u0648"
+    ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0444\u0443\u044d"
     ],
@@ -116,7 +119,13 @@
     "name:spa_x_preferred":[
         "Kafue"
     ],
+    "name:swa_x_preferred":[
+        "Kafue"
+    ],
     "name:swe_x_preferred":[
+        "Kafue"
+    ],
+    "name:szl_x_preferred":[
         "Kafue"
     ],
     "name:tam_x_preferred":[
@@ -127,6 +136,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e32\u0e1f\u0e39\u0e19\u0e4c"
+    ],
+    "name:tum_x_preferred":[
+        "Kafue"
     ],
     "name:tur_x_preferred":[
         "Kafue"
@@ -145,6 +157,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u5bcc\u57c3"
+    ],
+    "name:zul_x_preferred":[
+        "Kafue"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -286,7 +301,7 @@
         }
     ],
     "wof:id":421166477,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930105,
     "wof:name":"Kafue",
     "wof:parent_id":1108782417,
     "wof:placetype":"locality",

--- a/data/421/167/153/421167153.geojson
+++ b/data/421/167/153/421167153.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "Mwense District"
     ],
+    "name:deu_x_preferred":[
+        "Mwense"
+    ],
     "name:eng_x_preferred":[
         "Mwense District"
     ],
@@ -38,6 +41,9 @@
     "name:mrj_x_preferred":[
         "\u041c\u0432\u0435\u043dc\u0435"
     ],
+    "name:nan_x_preferred":[
+        "Mwense Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Mwense District"
     ],
@@ -49,6 +55,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u6eab\u585e\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Mwense District"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":421167153,
-    "wof:lastmodified":1566665953,
+    "wof:lastmodified":1690930107,
     "wof:name":"Mwense",
     "wof:parent_id":1108782409,
     "wof:placetype":"locality",

--- a/data/421/167/155/421167155.geojson
+++ b/data/421/167/155/421167155.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "Luwingu District"
     ],
+    "name:deu_x_preferred":[
+        "Luwingu"
+    ],
     "name:eng_x_preferred":[
         "Luwingu District"
     ],
@@ -38,6 +41,9 @@
     "name:mrj_x_preferred":[
         "\u041b\u0443\u0432\u0438\u043d\u0433\u0443"
     ],
+    "name:nan_x_preferred":[
+        "Luwingu Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Luwingu District"
     ],
@@ -49,6 +55,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76e7\u6eab\u53e4\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Luwingu District"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":421167155,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930107,
     "wof:name":"Luwingu",
     "wof:parent_id":1108782463,
     "wof:placetype":"locality",

--- a/data/421/167/157/421167157.geojson
+++ b/data/421/167/157/421167157.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0643\u0627\u0645\u0628\u0648\u0645\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0645\u0628\u0648\u0645\u0628\u0648"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09ac\u09cb\u09ae\u09cd\u09aa\u09cb"
     ],
@@ -104,6 +107,9 @@
     "name:zho_x_preferred":[
         "\u5361\u90a6\u6ce2"
     ],
+    "name:zul_x_preferred":[
+        "Kabompo"
+    ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":916246,
@@ -152,7 +158,7 @@
         }
     ],
     "wof:id":421167157,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930106,
     "wof:name":"Kabompo",
     "wof:parent_id":1108782443,
     "wof:placetype":"locality",

--- a/data/421/167/161/421167161.geojson
+++ b/data/421/167/161/421167161.geojson
@@ -50,6 +50,9 @@
     "name:zho_x_preferred":[
         "\u683c\u6eab\u8c9d"
     ],
+    "name:zul_x_preferred":[
+        "Gwembe"
+    ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":917011,
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421167161,
-    "wof:lastmodified":1566665953,
+    "wof:lastmodified":1690930106,
     "wof:name":"Gwembe",
     "wof:parent_id":1108782475,
     "wof:placetype":"locality",

--- a/data/421/167/163/421167163.geojson
+++ b/data/421/167/163/421167163.geojson
@@ -53,8 +53,17 @@
     "name:ron_x_preferred":[
         "Chama"
     ],
+    "name:szl_x_preferred":[
+        "Chama"
+    ],
+    "name:tum_x_preferred":[
+        "Chama"
+    ],
     "name:zho_x_preferred":[
         "\u6070\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Chama"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":421167163,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930107,
     "wof:name":"Chama",
     "wof:parent_id":1108782425,
     "wof:placetype":"locality",

--- a/data/421/168/087/421168087.geojson
+++ b/data/421/168/087/421168087.geojson
@@ -59,8 +59,14 @@
     "name:spa_x_preferred":[
         "Mkushi"
     ],
+    "name:swa_x_preferred":[
+        "Mkushi"
+    ],
     "name:zho_x_preferred":[
         "\u59c6\u5e93\u5e0c"
+    ],
+    "name:zul_x_preferred":[
+        "Mkushi"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":421168087,
-    "wof:lastmodified":1566665952,
+    "wof:lastmodified":1690930105,
     "wof:name":"Mkushi",
     "wof:parent_id":1108782357,
     "wof:placetype":"locality",

--- a/data/421/168/651/421168651.geojson
+++ b/data/421/168/651/421168651.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0631\u064a\u0641 \u0646\u0634\u064a\u0644\u0646\u062c\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u064a\u0641 \u0646\u0634\u064a\u0644\u0646\u062c\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Nchelenge"
+    ],
+    "name:avk_x_preferred":[
+        "Nchelenge"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09a8\u099a\u09c7\u09b2\u09c7\u0982\u0997\u09c7"
     ],
@@ -42,6 +51,9 @@
         "\u0627\u0646\u0686\u0644\u0646\u06af\u0647"
     ],
     "name:fra_x_preferred":[
+        "Nchelenge"
+    ],
+    "name:gle_x_preferred":[
         "Nchelenge"
     ],
     "name:heb_x_preferred":[
@@ -71,6 +83,9 @@
     "name:nld_x_preferred":[
         "Nchelenge"
     ],
+    "name:nob_x_preferred":[
+        "Nchelenge"
+    ],
     "name:pol_x_preferred":[
         "Nchelenge"
     ],
@@ -89,6 +104,9 @@
     "name:srp_x_preferred":[
         "\u041d\u0447\u0435\u043b\u0435\u043d\u0433\u0435"
     ],
+    "name:swa_x_preferred":[
+        "Nchelenge"
+    ],
     "name:swe_x_preferred":[
         "Nchelenge"
     ],
@@ -101,11 +119,17 @@
     "name:urd_x_preferred":[
         "\u0634\u06cc\u0644\u06cc\u0646\u06af\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Nchelenge"
+    ],
     "name:vie_x_preferred":[
         "Nchelenge"
     ],
     "name:zho_x_preferred":[
         "\u6069\u5207\u502b\u6208"
+    ],
+    "name:zul_x_preferred":[
+        "Nchelenge"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -247,7 +271,7 @@
         }
     ],
     "wof:id":421168651,
-    "wof:lastmodified":1636501935,
+    "wof:lastmodified":1690930104,
     "wof:name":"Nchelenge",
     "wof:parent_id":1108782411,
     "wof:placetype":"locality",

--- a/data/421/168/763/421168763.geojson
+++ b/data/421/168/763/421168763.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0641\u0648\u0644\u064a\u0631\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Mufulira"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c1\u09ab\u09c1\u09b2\u09bf\u09b0\u09be"
     ],
@@ -33,6 +36,9 @@
         "Mufulira"
     ],
     "name:ceb_x_preferred":[
+        "Mufulira"
+    ],
+    "name:ces_x_preferred":[
         "Mufulira"
     ],
     "name:dan_x_preferred":[
@@ -62,6 +68,9 @@
     "name:fra_x_preferred":[
         "Mufulira"
     ],
+    "name:gle_x_preferred":[
+        "Mufulira"
+    ],
     "name:heb_x_preferred":[
         "\u05de\u05d5\u05e4\u05d5\u05dc\u05d9\u05e8\u05d4"
     ],
@@ -77,11 +86,17 @@
     "name:ind_x_preferred":[
         "Mufulira"
     ],
+    "name:isl_x_preferred":[
+        "Mufulira"
+    ],
     "name:ita_x_preferred":[
         "Mufulira"
     ],
     "name:jpn_x_preferred":[
         "\u30e0\u30d5\u30ea\u30e9"
+    ],
+    "name:kal_x_preferred":[
+        "Mufulira"
     ],
     "name:kor_x_preferred":[
         "\ubb34\ud480\ub9ac\ub77c"
@@ -122,7 +137,16 @@
     "name:spa_x_preferred":[
         "Mufulira"
     ],
+    "name:swa_x_preferred":[
+        "Mufulira"
+    ],
     "name:swe_x_preferred":[
+        "Mufulira"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e21\u0e39\u0e1f\u0e38\u0e25\u0e34\u0e23\u0e32"
+    ],
+    "name:tum_x_preferred":[
         "Mufulira"
     ],
     "name:tur_x_preferred":[
@@ -134,6 +158,12 @@
     "name:urd_x_preferred":[
         "\u0645\u0648\u0641\u0648\u0644\u06cc\u0631\u0627"
     ],
+    "name:uzb_x_preferred":[
+        "Mufulira"
+    ],
+    "name:vec_x_preferred":[
+        "Mufulira"
+    ],
     "name:vie_x_preferred":[
         "Mufulira"
     ],
@@ -142,6 +172,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7a46\u5bcc\u5229\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Mufulira"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -285,7 +318,7 @@
         }
     ],
     "wof:id":421168763,
-    "wof:lastmodified":1636501935,
+    "wof:lastmodified":1690930104,
     "wof:name":"Mufulira",
     "wof:parent_id":1108782381,
     "wof:placetype":"locality",

--- a/data/421/168/765/421168765.geojson
+++ b/data/421/168/765/421168765.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0628\u064a\u0643\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0628\u064a\u0643\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u043f\u0456\u043a\u0430"
     ],
@@ -33,6 +36,9 @@
         "\u041c\u043f\u0438\u043a\u0430"
     ],
     "name:ceb_x_preferred":[
+        "Mpika"
+    ],
+    "name:ces_x_preferred":[
         "Mpika"
     ],
     "name:dan_x_preferred":[
@@ -128,6 +134,9 @@
     "name:spa_x_preferred":[
         "Mpika"
     ],
+    "name:swa_x_preferred":[
+        "Mpika"
+    ],
     "name:swe_x_preferred":[
         "Mpika"
     ],
@@ -157,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u76ae\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Mpika"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -298,7 +310,7 @@
         }
     ],
     "wof:id":421168765,
-    "wof:lastmodified":1636501935,
+    "wof:lastmodified":1690930104,
     "wof:name":"Mpika",
     "wof:parent_id":1108782433,
     "wof:placetype":"locality",

--- a/data/421/168/767/421168767.geojson
+++ b/data/421/168/767/421168767.geojson
@@ -23,7 +23,13 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u0633\u0627"
+    ],
     "name:ast_x_preferred":[
+        "Mansa"
+    ],
+    "name:avk_x_preferred":[
         "Mansa"
     ],
     "name:ben_x_preferred":[
@@ -34,6 +40,9 @@
     ],
     "name:ceb_x_preferred":[
         "Mansa"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0645\u0627\u0646\u0633\u0627"
     ],
     "name:deu_x_preferred":[
         "Mansa"
@@ -54,6 +63,9 @@
         "Mansa"
     ],
     "name:frr_x_preferred":[
+        "Mansa"
+    ],
+    "name:gle_x_preferred":[
         "Mansa"
     ],
     "name:heb_x_preferred":[
@@ -107,6 +119,9 @@
     "name:spa_x_preferred":[
         "Mansa"
     ],
+    "name:swa_x_preferred":[
+        "Mansa"
+    ],
     "name:swe_x_preferred":[
         "Mansa"
     ],
@@ -125,11 +140,17 @@
     "name:urd_x_variant":[
         "\u0645\u0627\u0646\u0633\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Mansa"
+    ],
     "name:vie_x_preferred":[
         "Mansa"
     ],
     "name:zho_x_preferred":[
         "\u66fc\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Mansa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -273,7 +294,7 @@
         }
     ],
     "wof:id":421168767,
-    "wof:lastmodified":1636501935,
+    "wof:lastmodified":1690930104,
     "wof:name":"Mansa",
     "wof:parent_id":1108782403,
     "wof:placetype":"locality",

--- a/data/421/168/769/421168769.geojson
+++ b/data/421/168/769/421168769.geojson
@@ -38,6 +38,9 @@
     "name:fas_x_preferred":[
         "\u0644\u0648\u0646\u062f\u0627\u0632\u06cc"
     ],
+    "name:fin_x_preferred":[
+        "Lundazi"
+    ],
     "name:fra_x_preferred":[
         "Lundazi"
     ],
@@ -83,6 +86,9 @@
     "name:spa_x_preferred":[
         "Lundazi"
     ],
+    "name:swa_x_preferred":[
+        "Lundazi"
+    ],
     "name:swe_x_preferred":[
         "Lundazi"
     ],
@@ -103,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9686\u9054\u6fdf"
+    ],
+    "name:zul_x_preferred":[
+        "Lundazi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -244,7 +253,7 @@
         }
     ],
     "wof:id":421168769,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930105,
     "wof:name":"Lundazi",
     "wof:parent_id":1108782391,
     "wof:placetype":"locality",

--- a/data/421/168/771/421168771.geojson
+++ b/data/421/168/771/421168771.geojson
@@ -27,10 +27,16 @@
         "\u0646\u0647\u0631 \u0644\u0648\u0627\u0646\u063a\u0648\u0627",
         "\u0646\u0647\u0631 \u0644\u0648\u0627\u0646\u063a\u0648\u0627\u060c \u0632\u0627\u0645\u0628\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0647\u0631 \u0644\u0648\u0627\u0646\u062c\u0648\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u09df\u09be\u0999\u09cd\u0997\u09cb\u09df\u09be"
     ],
     "name:ceb_x_preferred":[
+        "Luangwa"
+    ],
+    "name:dan_x_preferred":[
         "Luangwa"
     ],
     "name:deu_x_preferred":[
@@ -75,6 +81,9 @@
     "name:nld_x_preferred":[
         "Luangwa"
     ],
+    "name:nno_x_preferred":[
+        "Luangwa"
+    ],
     "name:nob_x_preferred":[
         "Luangwa"
     ],
@@ -116,6 +125,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76e7\u5b89\u6208\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Luangwa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Mozambique",
@@ -256,7 +268,7 @@
         }
     ],
     "wof:id":421168771,
-    "wof:lastmodified":1636501935,
+    "wof:lastmodified":1690930104,
     "wof:name":"Luangwa",
     "wof:parent_id":1091701729,
     "wof:placetype":"locality",

--- a/data/421/168/773/421168773.geojson
+++ b/data/421/168/773/421168773.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0633\u064a\u0645\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0633\u064a\u0645\u0628\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09b8\u09c7\u09ae\u09cd\u09aa\u09be"
     ],
     "name:bul_x_preferred":[
         "\u041a\u0430\u0441\u0435\u043c\u043f\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Kasempa"
     ],
     "name:ceb_x_preferred":[
         "Kasempa"
@@ -71,6 +77,9 @@
     "name:nld_x_preferred":[
         "Kasempa"
     ],
+    "name:pol_x_preferred":[
+        "Kasempa"
+    ],
     "name:por_x_preferred":[
         "Kasempa"
     ],
@@ -103,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u68ee\u5e15"
+    ],
+    "name:zul_x_preferred":[
+        "Kasempa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -244,7 +256,7 @@
         }
     ],
     "wof:id":421168773,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930105,
     "wof:name":"Kasempa",
     "wof:parent_id":1108782445,
     "wof:placetype":"locality",

--- a/data/421/169/385/421169385.geojson
+++ b/data/421/169/385/421169385.geojson
@@ -62,8 +62,14 @@
     "name:spa_x_preferred":[
         "Isoka"
     ],
+    "name:swa_x_preferred":[
+        "Isoka"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u7d22\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Isoka"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":421169385,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930108,
     "wof:name":"Isoka",
     "wof:parent_id":1108782429,
     "wof:placetype":"locality",

--- a/data/421/169/399/421169399.geojson
+++ b/data/421/169/399/421169399.geojson
@@ -59,11 +59,17 @@
     "name:spa_x_preferred":[
         "Monze"
     ],
+    "name:swa_x_preferred":[
+        "Monze"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u043e\u043d\u0437\u0435"
     ],
     "name:zho_x_preferred":[
         "\u8499\u6fa4"
+    ],
+    "name:zul_x_preferred":[
+        "Monze"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":421169399,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930107,
     "wof:name":"Monze",
     "wof:parent_id":1108782489,
     "wof:placetype":"locality",

--- a/data/421/170/925/421170925.geojson
+++ b/data/421/170/925/421170925.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u064a\u0646\u064a\u0644\u0648\u0646\u063a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u064a\u0646\u064a\u0644\u0648\u0646\u062c\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09ae\u0989\u0987\u09a8\u09bf\u09b2\u09c1\u09a8\u0999\u09cd\u0997\u09be"
     ],
@@ -89,6 +92,9 @@
     "name:spa_x_preferred":[
         "Mwinilunga"
     ],
+    "name:swa_x_preferred":[
+        "Mwinilunga"
+    ],
     "name:swe_x_preferred":[
         "Mwinilunga"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u7dad\u5c3c\u502b\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Mwinilunga"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -250,7 +259,7 @@
         }
     ],
     "wof:id":421170925,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930112,
     "wof:name":"Mwinilunga",
     "wof:parent_id":1108782449,
     "wof:placetype":"locality",

--- a/data/421/172/831/421172831.geojson
+++ b/data/421/172/831/421172831.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0632\u0627\u0628\u0648\u0643\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Mazabuka"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u0430\u0437\u0430\u0431\u0443\u043a\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u099c\u09be\u09ac\u09c1\u0995\u09be"
     ],
@@ -92,6 +98,9 @@
     "name:spa_x_preferred":[
         "Mazabuka"
     ],
+    "name:swa_x_preferred":[
+        "Mazabuka"
+    ],
     "name:swe_x_preferred":[
         "Mazabuka"
     ],
@@ -109,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u672d\u5e03\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Mazabuka"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -250,7 +262,7 @@
         }
     ],
     "wof:id":421172831,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930110,
     "wof:name":"Mazabuka",
     "wof:parent_id":1108782487,
     "wof:placetype":"locality",

--- a/data/421/173/197/421173197.geojson
+++ b/data/421/173/197/421173197.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0641\u064a\u0646\u063a\u0633\u062a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0641\u064a\u0646\u062c\u0633\u062a\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Livingstone"
     ],
@@ -39,6 +42,9 @@
         "Livingstone"
     ],
     "name:ceb_x_preferred":[
+        "Livingstone"
+    ],
+    "name:ces_x_preferred":[
         "Livingstone"
     ],
     "name:dan_x_preferred":[
@@ -80,6 +86,9 @@
     "name:fry_x_preferred":[
         "Livingstone"
     ],
+    "name:gle_x_preferred":[
+        "Livingstone"
+    ],
     "name:guj_x_preferred":[
         "\u0ab2\u0abf\u0ab5\u0abf\u0a82\u0a97\u0ab8\u0acd\u0a9f\u0acb\u0aa8"
     ],
@@ -97,6 +106,9 @@
     ],
     "name:hun_x_preferred":[
         "Livingstone"
+    ],
+    "name:hye_x_preferred":[
+        "\u053c\u056b\u057e\u056b\u0576\u0563\u057d\u0569\u0578\u0576"
     ],
     "name:ind_x_preferred":[
         "Livingstone"
@@ -124,6 +136,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0932\u093f\u0935\u093f\u0902\u0917\u094d\u0938\u094d\u091f\u094b\u0928"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0438\u0432\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
     "name:mrj_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043c\u0431\u0430"
@@ -158,6 +173,9 @@
     "name:sin_x_preferred":[
         "\u0dbd\u0dd2\u0dc0\u0dd2\u0db1\u0dca\u0d9c\u0dca\u0dc3\u0dca\u0da7\u0ddd\u0db1\u0dca"
     ],
+    "name:slk_x_preferred":[
+        "Livingstone"
+    ],
     "name:spa_x_preferred":[
         "Livingstone"
     ],
@@ -176,11 +194,17 @@
     "name:tha_x_preferred":[
         "\u0e25\u0e34\u0e1f\u0e27\u0e34\u0e07\u0e2a\u0e42\u0e15\u0e19"
     ],
+    "name:tum_x_preferred":[
+        "Livingstone"
+    ],
     "name:tur_x_preferred":[
         "Livingstone"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043c\u0431\u0430"
+    ],
+    "name:ukr_x_variant":[
+        "\u041b\u0456\u0432\u0456\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
     "name:und_x_variant":[
         "Livingstore"
@@ -191,11 +215,20 @@
     "name:urd_x_variant":[
         "\u0644\u06cc\u0648\u0646\u06af\u0633\u0679\u0648\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Livingstone"
+    ],
     "name:vie_x_preferred":[
+        "Livingstone"
+    ],
+    "name:war_x_preferred":[
         "Livingstone"
     ],
     "name:zho_x_preferred":[
         "\u5229\u6587\u65af\u987f"
+    ],
+    "name:zul_x_preferred":[
+        "Livingstone"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -340,7 +373,7 @@
         }
     ],
     "wof:id":421173197,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930109,
     "wof:name":"Livingstone",
     "wof:parent_id":1108782485,
     "wof:placetype":"locality",

--- a/data/421/174/121/421174121.geojson
+++ b/data/421/174/121/421174121.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u062a\u0648\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u06a9\u06cc\u062a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Kitwe"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u06cc\u062a\u0648"
     ],
@@ -31,6 +37,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0456\u0442\u0432\u044d"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0456\u0442\u0432\u044d"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09bf\u099f\u0993\u09af\u09bc\u09c7"
@@ -77,8 +86,14 @@
     "name:fra_x_preferred":[
         "Kitwe"
     ],
+    "name:gle_x_preferred":[
+        "Kitwe"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0abf\u0a9f\u0ab5\u0ac7"
+    ],
+    "name:hau_x_preferred":[
+        "Kitwe"
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d9\u05d8\u05d5\u05d5\u05d4"
@@ -134,6 +149,9 @@
     "name:nld_x_preferred":[
         "Kitwe"
     ],
+    "name:nno_x_preferred":[
+        "Kitwe"
+    ],
     "name:nob_x_preferred":[
         "Kitwe"
     ],
@@ -179,6 +197,9 @@
     "name:tha_x_preferred":[
         "\u0e04\u0e34\u0e15\u0e40\u0e27\u0e48"
     ],
+    "name:tum_x_preferred":[
+        "Kitwe"
+    ],
     "name:tur_x_preferred":[
         "Kitwe"
     ],
@@ -191,6 +212,9 @@
     "name:urd_x_preferred":[
         "\u06a9\u062a\u0648\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Kitwe"
+    ],
     "name:vie_x_preferred":[
         "Kitwe"
     ],
@@ -199,6 +223,9 @@
     ],
     "name:zho_x_preferred":[
         "\u57fa\u7279\u97e6"
+    ],
+    "name:zul_x_preferred":[
+        "Kitwe"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -343,7 +370,7 @@
         }
     ],
     "wof:id":421174121,
-    "wof:lastmodified":1566665955,
+    "wof:lastmodified":1690930109,
     "wof:name":"Kitwe",
     "wof:parent_id":1108782371,
     "wof:placetype":"locality",

--- a/data/421/175/739/421175739.geojson
+++ b/data/421/175/739/421175739.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0633\u0627\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0633\u0627\u0645\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Kasama"
+    ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0441\u0430\u043c\u0430"
     ],
@@ -60,6 +66,9 @@
         "Kasama"
     ],
     "name:frr_x_preferred":[
+        "Kasama"
+    ],
+    "name:gle_x_preferred":[
         "Kasama"
     ],
     "name:guj_x_preferred":[
@@ -137,6 +146,9 @@
     "name:spa_x_preferred":[
         "Kasama"
     ],
+    "name:swa_x_preferred":[
+        "Kasama"
+    ],
     "name:swe_x_preferred":[
         "Kasama"
     ],
@@ -148,6 +160,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e04\u0e32\u0e0b\u0e32\u0e21\u0e32"
+    ],
+    "name:tum_x_preferred":[
+        "Kasama"
     ],
     "name:tur_x_preferred":[
         "Kasama"
@@ -161,11 +176,17 @@
     "name:urd_x_variant":[
         "\u06a9\u0627\u0633\u0627\u0645\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Kasama"
+    ],
     "name:vie_x_preferred":[
         "Kasama"
     ],
     "name:zho_x_preferred":[
         "\u5361\u85a9\u99ac"
+    ],
+    "name:zul_x_preferred":[
+        "Kasama"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -309,7 +330,7 @@
         }
     ],
     "wof:id":421175739,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930110,
     "wof:name":"Kasama",
     "wof:parent_id":1108782461,
     "wof:placetype":"locality",

--- a/data/421/175/741/421175741.geojson
+++ b/data/421/175/741/421175741.geojson
@@ -23,11 +23,20 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0628\u064a\u0631\u064a \u0645\u0628\u0648\u0634\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0628\u064a\u0631\u0649 \u0645\u0628\u0648\u0634\u0649"
+    ],
+    "name:avk_x_preferred":[
+        "Kapiri Mposhi"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09aa\u09bf\u09b0\u09bf \u098f\u09ae\u09cd\u09aa\u09cb\u09b6\u09bf"
     ],
     "name:bul_x_preferred":[
         "\u041a\u0430\u043f\u0438\u0440\u0438 \u041c\u043f\u043e\u0448\u0438"
+    ],
+    "name:cat_x_preferred":[
+        "Kapiri Mposhi"
     ],
     "name:ceb_x_preferred":[
         "Kapiri Mposhi"
@@ -46,6 +55,9 @@
     ],
     "name:epo_x_preferred":[
         "Kapiri Mposhi"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u067e\u06cc\u0631\u06cc \u0627\u0645\u067e\u0648\u0634\u06cc"
     ],
     "name:fin_x_preferred":[
         "Kapiri Mposhi"
@@ -107,6 +119,9 @@
     "name:spa_x_preferred":[
         "Kapiri Mposhi"
     ],
+    "name:swa_x_preferred":[
+        "Kapiri Mposhi"
+    ],
     "name:swe_x_preferred":[
         "Kapiri Mposhi"
     ],
@@ -127,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u76ae\u91cc\u59c6\u6ce2\u5e0c"
+    ],
+    "name:zul_x_preferred":[
+        "Kapiri Mposhi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -268,7 +286,7 @@
         }
     ],
     "wof:id":421175741,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930110,
     "wof:name":"Kapiri Mposhi",
     "wof:parent_id":1108782355,
     "wof:placetype":"locality",

--- a/data/421/175/743/421175743.geojson
+++ b/data/421/175/743/421175743.geojson
@@ -89,6 +89,9 @@
     "name:spa_x_preferred":[
         "Kaoma"
     ],
+    "name:swa_x_preferred":[
+        "Kaoma"
+    ],
     "name:swe_x_preferred":[
         "Kaoma"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8003\u99ac"
+    ],
+    "name:zul_x_preferred":[
+        "Kaoma"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -250,7 +256,7 @@
         }
     ],
     "wof:id":421175743,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930111,
     "wof:name":"Kaoma",
     "wof:parent_id":1108782499,
     "wof:placetype":"locality",

--- a/data/421/176/937/421176937.geojson
+++ b/data/421/176/937/421176937.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Chibombo"
+    ],
     "name:ceb_x_preferred":[
         "Chibombo"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u90a6\u535a"
+    ],
+    "name:zul_x_preferred":[
+        "Chibombo"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -103,7 +109,7 @@
         }
     ],
     "wof:id":421176937,
-    "wof:lastmodified":1566665961,
+    "wof:lastmodified":1690930115,
     "wof:name":"Chibombo",
     "wof:parent_id":1108782349,
     "wof:placetype":"locality",

--- a/data/421/176/939/421176939.geojson
+++ b/data/421/176/939/421176939.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:avk_x_preferred":[
+        "Samfya"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0430\u043c\u0444\u044f"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:fra_x_preferred":[
         "Samfya"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05de\u05e4\u05d9\u05d4"
     ],
     "name:ita_x_preferred":[
         "Samfya"
@@ -53,11 +59,20 @@
     "name:ron_x_preferred":[
         "Samfya"
     ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043c\u0444\u044c\u044f"
+    ],
     "name:spa_x_preferred":[
+        "Samfya"
+    ],
+    "name:swa_x_preferred":[
         "Samfya"
     ],
     "name:zho_x_preferred":[
         "\u85a9\u59c6\u83f2\u4e9e"
+    ],
+    "name:zul_x_preferred":[
+        "Samfya"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -107,7 +122,7 @@
         }
     ],
     "wof:id":421176939,
-    "wof:lastmodified":1566665961,
+    "wof:lastmodified":1690930115,
     "wof:name":"Samfya",
     "wof:parent_id":1108782413,
     "wof:placetype":"locality",

--- a/data/421/176/941/421176941.geojson
+++ b/data/421/176/941/421176941.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0646\u0647\u0631 \u0632\u0627\u0645\u0628\u064a\u0632\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0647\u0631 \u0632\u0627\u0645\u0628\u064a\u0632\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0417\u0430\u043c\u0431\u0435\u0437\u0438"
     ],
@@ -148,6 +151,9 @@
     ],
     "name:zho_x_variant":[
         "\u8d0a\u6bd4\u897f"
+    ],
+    "name:zul_x_preferred":[
+        "Zambezi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -289,7 +295,7 @@
         }
     ],
     "wof:id":421176941,
-    "wof:lastmodified":1636501940,
+    "wof:lastmodified":1690930116,
     "wof:name":"Zambezi",
     "wof:parent_id":1108782453,
     "wof:placetype":"locality",

--- a/data/421/176/943/421176943.geojson
+++ b/data/421/176/943/421176943.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0644\u0648\u064a\u0632\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Solwezi"
+    ],
+    "name:bel_x_preferred":[
+        "\u0421\u043e\u043b\u0432\u0435\u0437\u0456"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u09b2\u09c7\u0987\u099c\u09bf"
     ],
@@ -47,6 +53,9 @@
     "name:fas_x_preferred":[
         "\u0633\u0648\u0644\u0648\u0632\u06cc"
     ],
+    "name:fin_x_preferred":[
+        "Solwezi"
+    ],
     "name:fra_x_preferred":[
         "Solwezi"
     ],
@@ -55,6 +64,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e1\u05d5\u05dc\u05d1\u05d6\u05d9"
+    ],
+    "name:heb_x_variant":[
+        "\u05e1\u05d5\u05dc\u05d5\u05d5\u05d6\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0938\u094b\u0932\u0935\u0947\u091c\u093c\u0940"
@@ -107,7 +119,13 @@
     "name:spa_x_preferred":[
         "Solwezi"
     ],
+    "name:swa_x_preferred":[
+        "Solwezi"
+    ],
     "name:swe_x_preferred":[
+        "Solwezi"
+    ],
+    "name:tum_x_preferred":[
         "Solwezi"
     ],
     "name:tur_x_preferred":[
@@ -124,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d22\u76e7\u97cb\u9f4a"
+    ],
+    "name:zul_x_preferred":[
+        "Solwezi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -267,7 +288,7 @@
         }
     ],
     "wof:id":421176943,
-    "wof:lastmodified":1636501940,
+    "wof:lastmodified":1690930116,
     "wof:name":"Solwezi",
     "wof:parent_id":1108782451,
     "wof:placetype":"locality",

--- a/data/421/176/945/421176945.geojson
+++ b/data/421/176/945/421176945.geojson
@@ -86,6 +86,9 @@
     "name:swe_x_preferred":[
         "Lukulu"
     ],
+    "name:tsn_x_preferred":[
+        "Lukulu"
+    ],
     "name:tur_x_preferred":[
         "Lukulu"
     ],
@@ -100,6 +103,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76e7\u5eab\u76e7"
+    ],
+    "name:zul_x_preferred":[
+        "Lukulu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -241,7 +247,7 @@
         }
     ],
     "wof:id":421176945,
-    "wof:lastmodified":1636501940,
+    "wof:lastmodified":1690930116,
     "wof:name":"Lukulu",
     "wof:parent_id":1108782501,
     "wof:placetype":"locality",

--- a/data/421/176/965/421176965.geojson
+++ b/data/421/176/965/421176965.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0634\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0634\u064a\u0643"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09b6\u09c7\u0995\u09c7"
     ],
@@ -92,6 +95,9 @@
     "name:spa_x_preferred":[
         "Sesheke"
     ],
+    "name:swa_x_preferred":[
+        "Sesheke"
+    ],
     "name:swe_x_preferred":[
         "Sesheke"
     ],
@@ -112,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u8b1d\u51f1"
+    ],
+    "name:zul_x_preferred":[
+        "Sesheke"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -253,7 +262,7 @@
         }
     ],
     "wof:id":421176965,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930115,
     "wof:name":"Sesheke",
     "wof:parent_id":1108782507,
     "wof:placetype":"locality",

--- a/data/421/178/357/421178357.geojson
+++ b/data/421/178/357/421178357.geojson
@@ -23,11 +23,23 @@
     "name:ara_x_preferred":[
         "\u062a\u0634\u064a\u0628\u0627\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0634\u064a\u0628\u0627\u062a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Chipata"
+    ],
+    "name:avk_x_preferred":[
+        "Chipata"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09bf\u09aa\u09be\u09a4\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0427\u0438\u043f\u0430\u0442\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Chipata"
     ],
     "name:ceb_x_preferred":[
         "Chipata"
@@ -62,6 +74,9 @@
     "name:heb_x_preferred":[
         "\u05e6'\u05d9\u05e4\u05d8\u05d4"
     ],
+    "name:heb_x_variant":[
+        "\u05e6'\u05d9\u05e4\u05d0\u05d8\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u091a\u093f\u092a\u093e\u0924\u093e"
     ],
@@ -70,6 +85,9 @@
     ],
     "name:hun_x_preferred":[
         "Chipata"
+    ],
+    "name:hye_x_preferred":[
+        "\u0549\u056b\u057a\u0561\u057f\u0561"
     ],
     "name:ind_x_preferred":[
         "Chipata"
@@ -131,6 +149,9 @@
     "name:spa_x_preferred":[
         "Chipata"
     ],
+    "name:swa_x_preferred":[
+        "Chipata"
+    ],
     "name:swe_x_preferred":[
         "Chipata"
     ],
@@ -142,6 +163,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e0a\u0e35\u0e1b\u0e32\u0e15\u0e32"
+    ],
+    "name:tum_x_preferred":[
+        "Chipata"
     ],
     "name:tur_x_preferred":[
         "Chipata"
@@ -158,8 +182,14 @@
     "name:vie_x_preferred":[
         "Chipata"
     ],
+    "name:war_x_preferred":[
+        "Chipata"
+    ],
     "name:zho_x_preferred":[
         "\u5947\u5e15\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Chipata"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -303,7 +333,7 @@
         }
     ],
     "wof:id":421178357,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930114,
     "wof:name":"Chipata",
     "wof:parent_id":1108782391,
     "wof:placetype":"locality",

--- a/data/421/178/367/421178367.geojson
+++ b/data/421/178/367/421178367.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0634\u0648\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0634\u0648\u0645\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09cb\u09ae\u09be"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u55ac\u99ac"
+    ],
+    "name:zul_x_preferred":[
+        "Choma"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -250,7 +256,7 @@
         }
     ],
     "wof:id":421178367,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930114,
     "wof:name":"Choma",
     "wof:parent_id":1108782473,
     "wof:placetype":"locality",

--- a/data/421/178/369/421178369.geojson
+++ b/data/421/178/369/421178369.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0634\u064a\u0646\u063a\u0648\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u064a\u0646\u062c\u0648\u0644\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Chingola"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09bf\u0982\u0997\u09cb\u09b2\u09be"
     ],
@@ -54,6 +60,9 @@
         "Chingola"
     ],
     "name:fra_x_preferred":[
+        "Chingola"
+    ],
+    "name:gle_x_preferred":[
         "Chingola"
     ],
     "name:heb_x_preferred":[
@@ -107,7 +116,13 @@
     "name:spa_x_preferred":[
         "Chingola"
     ],
+    "name:swa_x_preferred":[
+        "Chingola"
+    ],
     "name:swe_x_preferred":[
+        "Chingola"
+    ],
+    "name:tum_x_preferred":[
         "Chingola"
     ],
     "name:tur_x_preferred":[
@@ -122,6 +137,9 @@
     "name:urd_x_preferred":[
         "\u0686\u0646\u06af\u0648\u0644\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Chingola"
+    ],
     "name:vie_x_preferred":[
         "Chingola"
     ],
@@ -130,6 +148,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6b3d\u6208\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Chingola"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -281,7 +302,7 @@
         }
     ],
     "wof:id":421178369,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930114,
     "wof:name":"Chingola",
     "wof:parent_id":1108782363,
     "wof:placetype":"locality",

--- a/data/421/178/937/421178937.geojson
+++ b/data/421/178/937/421178937.geojson
@@ -31,16 +31,28 @@
     "name:arg_x_preferred":[
         "Lusaka"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0648\u0635\u0627\u0643\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u0648\u0633\u0627\u0643\u0627"
     ],
     "name:ast_x_preferred":[
         "Lusaka"
     ],
+    "name:avk_x_preferred":[
+        "Lusaka"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u0648\u0633\u0627\u06a9\u0627"
     ],
     "name:aze_x_preferred":[
+        "Lusaka"
+    ],
+    "name:bak_x_preferred":[
+        "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
+    "name:ban_x_preferred":[
         "Lusaka"
     ],
     "name:bel_x_preferred":[
@@ -106,10 +118,16 @@
     "name:eus_x_preferred":[
         "Lusaka"
     ],
+    "name:ext_x_preferred":[
+        "Lusaka"
+    ],
     "name:fas_x_preferred":[
         "\u0644\u0648\u0633\u0627\u06a9\u0627"
     ],
     "name:fin_x_preferred":[
+        "Lusaka"
+    ],
+    "name:fit_x_preferred":[
         "Lusaka"
     ],
     "name:fra_x_preferred":[
@@ -226,7 +244,13 @@
     "name:lav_x_preferred":[
         "Lusaka"
     ],
+    "name:lfn_x_preferred":[
+        "Lusaka"
+    ],
     "name:lij_x_preferred":[
+        "Lusaka"
+    ],
+    "name:lin_x_preferred":[
         "Lusaka"
     ],
     "name:lit_x_preferred":[
@@ -244,6 +268,12 @@
     "name:mar_x_preferred":[
         "\u0932\u0941\u0938\u093e\u0915\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
     "name:mkd_x_preferred":[
         "\u041b\u0443\u0441\u0430\u043a\u0430"
     ],
@@ -258,6 +288,9 @@
     ],
     "name:msa_x_preferred":[
         "Lusaka"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0644\u0648\u0633\u0627\u06a9\u0627"
     ],
     "name:nah_x_preferred":[
         "Lusaka"
@@ -319,11 +352,17 @@
     "name:que_x_preferred":[
         "Lusaka"
     ],
+    "name:rmf_x_preferred":[
+        "Lusaka"
+    ],
     "name:ron_x_preferred":[
         "Lusaka"
     ],
     "name:rus_x_preferred":[
         "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c5e\u1c69\u1c65\u1c5f\u1c60\u1c5f"
     ],
     "name:sco_x_preferred":[
         "Lusaka"
@@ -331,10 +370,34 @@
     "name:sin_x_preferred":[
         "\u0dbd\u0dd4\u0dc3\u0dcf\u0d9a\u0dcf"
     ],
+    "name:sjd_x_preferred":[
+        "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
+    "name:sje_x_preferred":[
+        "Lusaka"
+    ],
+    "name:sju_x_preferred":[
+        "Lusaka"
+    ],
     "name:slk_x_preferred":[
         "Lusaka"
     ],
     "name:slv_x_preferred":[
+        "Lusaka"
+    ],
+    "name:sma_x_preferred":[
+        "Lusaka"
+    ],
+    "name:sme_x_preferred":[
+        "Lusaka"
+    ],
+    "name:smj_x_preferred":[
+        "Lusaka"
+    ],
+    "name:smn_x_preferred":[
+        "Lusaka"
+    ],
+    "name:sms_x_preferred":[
         "Lusaka"
     ],
     "name:sna_x_preferred":[
@@ -349,8 +412,14 @@
     "name:sqi_x_preferred":[
         "Lusaka"
     ],
+    "name:srd_x_preferred":[
+        "Lusaka"
+    ],
     "name:srp_x_preferred":[
         "\u041b\u0443\u0441\u0430\u043a\u0430"
+    ],
+    "name:ssw_x_preferred":[
+        "Lusaka"
     ],
     "name:swa_x_preferred":[
         "Lusaka"
@@ -441,6 +510,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8def\u6c99\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Lusaka"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Zambia",
@@ -601,7 +673,7 @@
         }
     ],
     "wof:id":421178937,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930114,
     "wof:megacity":1,
     "wof:name":"Lusaka",
     "wof:parent_id":1108782421,

--- a/data/421/179/673/421179673.geojson
+++ b/data/421/179/673/421179673.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0648\u0627\u0645\u0628\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0648\u0627\u0645\u0628\u0648\u0627"
+    ],
+    "name:avk_x_preferred":[
+        "Kawambwa"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0993\u09df\u09be\u09ae\u09cd\u09ac\u09cb\u09df\u09be"
     ],
@@ -40,6 +46,9 @@
     ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0648\u0627\u0645\u0628\u0648\u0627"
+    ],
+    "name:fin_x_preferred":[
+        "Kawambwa"
     ],
     "name:fra_x_preferred":[
         "Kawambwa"
@@ -86,6 +95,9 @@
     "name:spa_x_preferred":[
         "Kawambwa"
     ],
+    "name:swa_x_preferred":[
+        "Kawambwa"
+    ],
     "name:swe_x_preferred":[
         "Kawambwa"
     ],
@@ -106,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u842c\u5e03\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Kawambwa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -247,7 +262,7 @@
         }
     ],
     "wof:id":421179673,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930113,
     "wof:name":"Kawambwa",
     "wof:parent_id":1108782401,
     "wof:placetype":"locality",

--- a/data/421/179/923/421179923.geojson
+++ b/data/421/179/923/421179923.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0628\u0627\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0628\u0627\u0644\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09ae\u09ac\u09be\u09b2\u09be"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d1\u05dc\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05de\u05d1\u05d0\u05dc\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u092e\u094d\u092c\u093e\u0932\u093e"
@@ -98,6 +104,9 @@
     "name:spa_x_preferred":[
         "Mbala"
     ],
+    "name:swa_x_preferred":[
+        "Mbala"
+    ],
     "name:swe_x_preferred":[
         "Mbala"
     ],
@@ -118,6 +127,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u5df4\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Mbala"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -259,7 +271,7 @@
         }
     ],
     "wof:id":421179923,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930113,
     "wof:name":"Mbala",
     "wof:parent_id":1108782465,
     "wof:placetype":"locality",

--- a/data/421/179/935/421179935.geojson
+++ b/data/421/179/935/421179935.geojson
@@ -23,11 +23,23 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0628\u0648\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0628\u0648\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Kabwe"
+    ],
+    "name:avk_x_preferred":[
+        "Kabwe"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0627\u0628\u0648\u0648\u06cc"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u0431\u0432\u044d"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0430\u0431\u0432\u044d"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09ac\u09cb\u09df\u09c7"
@@ -74,6 +86,9 @@
     "name:frr_x_preferred":[
         "Kabwe"
     ],
+    "name:gle_x_preferred":[
+        "Kabwe"
+    ],
     "name:heb_x_preferred":[
         "\u05e7\u05d1\u05d5\u05d5\u05d4"
     ],
@@ -86,6 +101,9 @@
     "name:hun_x_preferred":[
         "Kabwe"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0561\u0562\u057e\u0565"
+    ],
     "name:ind_x_preferred":[
         "Kabwe"
     ],
@@ -94,6 +112,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30d6\u30a6\u30a7"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d9\u10d0\u10d1\u10d5\u10d4"
     ],
     "name:kor_x_preferred":[
         "\uce74\ube0c\uc6e8"
@@ -131,7 +152,13 @@
     "name:spa_x_preferred":[
         "Kabwe"
     ],
+    "name:swa_x_preferred":[
+        "Kabwe"
+    ],
     "name:swe_x_preferred":[
+        "Kabwe"
+    ],
+    "name:szl_x_preferred":[
         "Kabwe"
     ],
     "name:tgl_x_preferred":[
@@ -149,6 +176,12 @@
     "name:urd_x_preferred":[
         "\u06a9\u0627\u0628\u0648\u06d2"
     ],
+    "name:uzb_x_preferred":[
+        "Kabve"
+    ],
+    "name:vec_x_preferred":[
+        "Kabwe"
+    ],
     "name:vie_x_preferred":[
         "Kabwe"
     ],
@@ -157,6 +190,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u5e03\u97e6"
+    ],
+    "name:zul_x_preferred":[
+        "Kabwe"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -300,7 +336,7 @@
         }
     ],
     "wof:id":421179935,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930113,
     "wof:name":"Kabwe",
     "wof:parent_id":1108782353,
     "wof:placetype":"locality",

--- a/data/421/179/971/421179971.geojson
+++ b/data/421/179/971/421179971.geojson
@@ -26,6 +26,9 @@
     "name:bul_x_preferred":[
         "\u041c\u0443\u043c\u0431\u0443\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Mumbwa"
+    ],
     "name:ceb_x_preferred":[
         "Mumbwa"
     ],
@@ -86,6 +89,9 @@
     "name:spa_x_preferred":[
         "Mumbwa"
     ],
+    "name:swa_x_preferred":[
+        "Mumbwa"
+    ],
     "name:swe_x_preferred":[
         "Mumbwa"
     ],
@@ -103,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8499\u5e03\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Mumbwa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -244,7 +253,7 @@
         }
     ],
     "wof:id":421179971,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930113,
     "wof:name":"Mumbwa",
     "wof:parent_id":1108782359,
     "wof:placetype":"locality",

--- a/data/421/181/197/421181197.geojson
+++ b/data/421/181/197/421181197.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u0627\u0646\u0634\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0627\u0646\u0634\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Luanshya"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u09af\u09bc\u09be\u09a8\u09b6\u09bf\u09af\u09bc\u09be"
     ],
@@ -57,6 +63,9 @@
         "Luanshya"
     ],
     "name:fra_x_preferred":[
+        "Luanshya"
+    ],
+    "name:gle_x_preferred":[
         "Luanshya"
     ],
     "name:guj_x_preferred":[
@@ -131,6 +140,9 @@
     "name:spa_x_preferred":[
         "Luanshya"
     ],
+    "name:swa_x_preferred":[
+        "Luanshya"
+    ],
     "name:swe_x_preferred":[
         "Luanshya"
     ],
@@ -142,6 +154,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e25\u0e27\u0e19\u0e0a\u0e22\u0e32"
+    ],
+    "name:tum_x_preferred":[
+        "Luanshya"
     ],
     "name:tur_x_preferred":[
         "Luanshya"
@@ -155,6 +170,12 @@
     "name:urd_x_preferred":[
         "\u0644\u0648\u0627\u0646\u0634\u06cc\u0627"
     ],
+    "name:uzb_x_preferred":[
+        "Luanshya"
+    ],
+    "name:vec_x_preferred":[
+        "Luanshya"
+    ],
     "name:vie_x_preferred":[
         "Luanshya"
     ],
@@ -163,6 +184,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76e7\u5b89\u590f"
+    ],
+    "name:zul_x_preferred":[
+        "Luanshya"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -306,7 +330,7 @@
         }
     ],
     "wof:id":421181197,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930110,
     "wof:name":"Luanshya",
     "wof:parent_id":1108782373,
     "wof:placetype":"locality",

--- a/data/421/182/779/421182779.geojson
+++ b/data/421/182/779/421182779.geojson
@@ -23,6 +23,9 @@
     "name:fra_x_preferred":[
         "Chambishi F.C."
     ],
+    "name:lit_x_preferred":[
+        "Chambishi"
+    ],
     "name:nld_x_preferred":[
         "Chambishi F.C."
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":421182779,
-    "wof:lastmodified":1566665961,
+    "wof:lastmodified":1690930115,
     "wof:name":"Chambishi",
     "wof:parent_id":1108782367,
     "wof:placetype":"locality",

--- a/data/421/182/785/421182785.geojson
+++ b/data/421/182/785/421182785.geojson
@@ -68,6 +68,9 @@
     "name:mrj_x_preferred":[
         "\u041d\u044c\u0438\u043c\u0431\u0430"
     ],
+    "name:nan_x_preferred":[
+        "Nyimba Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Nyimba District"
     ],
@@ -100,6 +103,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u56e0\u5df4\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Nyimba District"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -240,7 +246,7 @@
         }
     ],
     "wof:id":421182785,
-    "wof:lastmodified":1636501939,
+    "wof:lastmodified":1690930115,
     "wof:name":"Nyimba",
     "wof:parent_id":1108782395,
     "wof:placetype":"locality",

--- a/data/421/185/567/421185567.geojson
+++ b/data/421/185/567/421185567.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u0627\u0641\u0648\u0646\u063a\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0627\u0641\u0648\u0646\u062c\u0627"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0438\u0430\u0432\u043e\u043d\u0433\u0430"
     ],
@@ -30,6 +36,9 @@
         "Siavonga"
     ],
     "name:fra_x_preferred":[
+        "Siavonga"
+    ],
+    "name:hun_x_preferred":[
         "Siavonga"
     ],
     "name:ita_x_preferred":[
@@ -56,11 +65,17 @@
     "name:spa_x_preferred":[
         "Siavonga"
     ],
+    "name:swa_x_preferred":[
+        "Siavonga"
+    ],
     "name:und_x_variant":[
         "Chapvonga"
     ],
     "name:zho_x_preferred":[
         "\u5e0c\u4e9e\u8c50\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Siavonga"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":421185567,
-    "wof:lastmodified":1566665962,
+    "wof:lastmodified":1690930116,
     "wof:name":"Siavonga",
     "wof:parent_id":890427539,
     "wof:placetype":"locality",

--- a/data/421/188/251/421188251.geojson
+++ b/data/421/188/251/421188251.geojson
@@ -53,8 +53,14 @@
     "name:spa_x_preferred":[
         "Chadiza"
     ],
+    "name:tum_x_preferred":[
+        "Chadiza"
+    ],
     "name:zho_x_preferred":[
         "\u6070\u8fea\u624e"
+    ],
+    "name:zul_x_preferred":[
+        "Chadiza"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421188251,
-    "wof:lastmodified":1566665956,
+    "wof:lastmodified":1690930109,
     "wof:name":"Chadiza",
     "wof:parent_id":1108782385,
     "wof:placetype":"locality",

--- a/data/421/188/253/421188253.geojson
+++ b/data/421/188/253/421188253.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0646\u0627\u0646\u063a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0646\u0627\u0646\u062c\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09be\u0997\u09be"
     ],
@@ -59,6 +62,9 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30ca\u30f3\u30ac"
     ],
+    "name:kat_x_preferred":[
+        "\u10e1\u10d4\u10dc\u10d0\u10dc\u10d2\u10d0"
+    ],
     "name:kor_x_preferred":[
         "\uc138\ub0ad\uac00"
     ],
@@ -89,6 +95,9 @@
     "name:spa_x_preferred":[
         "Senanga"
     ],
+    "name:swa_x_preferred":[
+        "Senanga"
+    ],
     "name:swe_x_preferred":[
         "Senanga"
     ],
@@ -109,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u5357\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Senanga"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -250,7 +262,7 @@
         }
     ],
     "wof:id":421188253,
-    "wof:lastmodified":1636501936,
+    "wof:lastmodified":1690930109,
     "wof:name":"Senanga",
     "wof:parent_id":1108782505,
     "wof:placetype":"locality",

--- a/data/421/194/171/421194171.geojson
+++ b/data/421/194/171/421194171.geojson
@@ -41,6 +41,9 @@
     "name:nld_x_preferred":[
         "Namwala"
     ],
+    "name:pol_x_preferred":[
+        "Namwala"
+    ],
     "name:por_x_preferred":[
         "Namwala"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421194171,
-    "wof:lastmodified":1566665953,
+    "wof:lastmodified":1690930106,
     "wof:name":"Namwala",
     "wof:parent_id":1108782491,
     "wof:placetype":"locality",

--- a/data/421/195/137/421195137.geojson
+++ b/data/421/195/137/421195137.geojson
@@ -23,6 +23,9 @@
     "name:nld_x_preferred":[
         "Shiwa Ngandu"
     ],
+    "name:zul_x_preferred":[
+        "Shiwa Ngandu"
+    ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":898494,
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":421195137,
-    "wof:lastmodified":1566665953,
+    "wof:lastmodified":1690930106,
     "wof:name":"Shiwa Ngandu",
     "wof:parent_id":1108782427,
     "wof:placetype":"locality",

--- a/data/421/195/225/421195225.geojson
+++ b/data/421/195/225/421195225.geojson
@@ -17,8 +17,14 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Kazungula"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u0430\u0437\u0443\u043d\u0433\u0443\u043b\u0430"
+    ],
+    "name:ces_x_preferred":[
+        "Kazungula"
     ],
     "name:deu_x_preferred":[
         "Kazungula"
@@ -26,8 +32,14 @@
     "name:eng_x_preferred":[
         "Kazungula"
     ],
+    "name:fin_x_preferred":[
+        "Kazungula"
+    ],
     "name:fra_x_preferred":[
         "Kazungula"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d6\u05d5\u05e0\u05d2\u05d5\u05dc\u05d4"
     ],
     "name:hye_x_preferred":[
         "\u053f\u0561\u0566\u0578\u0582\u0576\u0563\u0578\u0582\u056c\u0561"
@@ -53,6 +65,9 @@
     "name:rus_x_preferred":[
         "\u041a\u0430\u0437\u0443\u043d\u0433\u0443\u043b\u0430"
     ],
+    "name:swe_x_preferred":[
+        "Kazungula"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0437\u0443\u043d\u0433\u0443\u043b\u0430"
     ],
@@ -61,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u5b97\u53e4\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Kazungula"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -109,7 +127,7 @@
         }
     ],
     "wof:id":421195225,
-    "wof:lastmodified":1566665953,
+    "wof:lastmodified":1690930106,
     "wof:name":"Kazungula",
     "wof:parent_id":1108782483,
     "wof:placetype":"locality",

--- a/data/421/197/195/421197195.geojson
+++ b/data/421/197/195/421197195.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0646\u062f\u0648\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u062f\u0648\u0644\u0627"
+    ],
     "name:ast_x_preferred":[
         "Ndola"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041d\u0434\u043e\u043b\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041d\u0434\u043e\u043b\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a8\u09cb\u09a6\u09b2\u09be"
@@ -80,8 +86,14 @@
     "name:frr_x_preferred":[
         "Ndola"
     ],
+    "name:gle_x_preferred":[
+        "Ndola"
+    ],
     "name:guj_x_preferred":[
         "\u0a8f\u0aa8\u0acd\u0aa1\u0acb\u0ab2\u0abe"
+    ],
+    "name:hau_x_preferred":[
+        "Ndola"
     ],
     "name:heb_x_preferred":[
         "\u05e0\u05d3\u05d5\u05dc\u05d4"
@@ -130,6 +142,12 @@
     ],
     "name:mar_x_preferred":[
         "\u0928\u0921\u094b\u0932\u093e"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041d\u0434\u043e\u043b\u0430"
+    ],
+    "name:mlt_x_preferred":[
+        "Ndola"
     ],
     "name:mrj_x_preferred":[
         "\u041d\u0434\u043e\u043b\u0430"
@@ -188,6 +206,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e2d\u0e47\u0e19\u0e42\u0e14\u0e25\u0e32"
     ],
+    "name:tum_x_preferred":[
+        "Ndola"
+    ],
     "name:tur_x_preferred":[
         "Ndola"
     ],
@@ -200,6 +221,9 @@
     "name:uzb_x_preferred":[
         "Ndola"
     ],
+    "name:vec_x_preferred":[
+        "Ndola"
+    ],
     "name:vie_x_preferred":[
         "Ndola"
     ],
@@ -208,6 +232,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u591a\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Ndola"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -354,7 +381,7 @@
         }
     ],
     "wof:id":421197195,
-    "wof:lastmodified":1566665958,
+    "wof:lastmodified":1690930112,
     "wof:name":"Ndola",
     "wof:parent_id":1108782383,
     "wof:placetype":"locality",

--- a/data/421/197/931/421197931.geojson
+++ b/data/421/197/931/421197931.geojson
@@ -44,6 +44,9 @@
     "name:spa_x_preferred":[
         "Kansanshi"
     ],
+    "name:swa_x_preferred":[
+        "Kansanshi"
+    ],
     "name:und_x_variant":[
         "Kansanshi Mine"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421197931,
-    "wof:lastmodified":1566665958,
+    "wof:lastmodified":1690930111,
     "wof:name":"Kansanshi",
     "wof:parent_id":1108782451,
     "wof:placetype":"locality",

--- a/data/421/198/109/421198109.geojson
+++ b/data/421/198/109/421198109.geojson
@@ -23,6 +23,9 @@
     "name:nld_x_preferred":[
         "Chilenje"
     ],
+    "name:tum_x_preferred":[
+        "Chilenje"
+    ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":919568,
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421198109,
-    "wof:lastmodified":1566665958,
+    "wof:lastmodified":1690930111,
     "wof:name":"Chilenje",
     "wof:parent_id":1108782421,
     "wof:placetype":"locality",

--- a/data/421/198/635/421198635.geojson
+++ b/data/421/198/635/421198635.geojson
@@ -71,6 +71,9 @@
     "name:spa_x_preferred":[
         "Kalulushi"
     ],
+    "name:swa_x_preferred":[
+        "Kalulushi"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043b\u0443\u043b\u0443\u0448\u0456"
     ],
@@ -79,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u76e7\u76e7\u5e0c"
+    ],
+    "name:zul_x_preferred":[
+        "Kalulushi"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":421198635,
-    "wof:lastmodified":1566665957,
+    "wof:lastmodified":1690930111,
     "wof:name":"Kalulushi",
     "wof:parent_id":1108782371,
     "wof:placetype":"locality",

--- a/data/421/199/121/421199121.geojson
+++ b/data/421/199/121/421199121.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0644\u0627\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0644\u0627\u0628\u0648"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09b2\u09be\u09ac\u09cb"
     ],
@@ -97,6 +100,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u62c9\u535a"
+    ],
+    "name:zul_x_preferred":[
+        "Kalabo"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -238,7 +244,7 @@
         }
     ],
     "wof:id":421199121,
-    "wof:lastmodified":1636501937,
+    "wof:lastmodified":1690930112,
     "wof:name":"Kalabo",
     "wof:parent_id":1108782497,
     "wof:placetype":"locality",

--- a/data/421/200/281/421200281.geojson
+++ b/data/421/200/281/421200281.geojson
@@ -20,13 +20,28 @@
     "name:ara_x_preferred":[
         "\u062a\u0634\u064a\u0646\u0633\u0627\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0634\u064a\u0646\u0633\u0627\u0644\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09bf\u09a8\u09b8\u09be\u09b2\u09bf"
     ],
     "name:bul_x_preferred":[
         "\u0427\u0438\u043d\u0441\u0430\u043b\u0438"
     ],
+    "name:cat_x_preferred":[
+        "Chinsali"
+    ],
     "name:ceb_x_preferred":[
+        "Chinsali"
+    ],
+    "name:ces_x_preferred":[
+        "Chinsali"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0686\u06cc\u0646\u0633\u0627\u0644\u06cc"
+    ],
+    "name:dan_x_preferred":[
         "Chinsali"
     ],
     "name:deu_x_preferred":[
@@ -101,6 +116,15 @@
     "name:spa_x_preferred":[
         "Chinsali"
     ],
+    "name:swa_x_preferred":[
+        "Chinsali"
+    ],
+    "name:swe_x_preferred":[
+        "Chinsali"
+    ],
+    "name:szl_x_preferred":[
+        "Chinsali"
+    ],
     "name:tur_x_preferred":[
         "Chinsali"
     ],
@@ -118,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6b3d\u85a9\u5229"
+    ],
+    "name:zul_x_preferred":[
+        "Chinsali"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -259,7 +286,7 @@
         }
     ],
     "wof:id":421200281,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930112,
     "wof:name":"Chinsali",
     "wof:parent_id":1108782427,
     "wof:placetype":"locality",

--- a/data/421/201/997/421201997.geojson
+++ b/data/421/201/997/421201997.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0646\u063a\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Mongu"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u0999\u09cd\u0997\u09c1"
     ],
@@ -30,6 +33,9 @@
         "\u041c\u043e\u043d\u0433\u0443"
     ],
     "name:cat_x_preferred":[
+        "Mongu"
+    ],
+    "name:ceb_x_preferred":[
         "Mongu"
     ],
     "name:dan_x_preferred":[
@@ -47,11 +53,17 @@
     "name:fas_x_preferred":[
         "\u0645\u0648\u0646\u06af\u0648"
     ],
+    "name:fin_x_preferred":[
+        "Mongu"
+    ],
     "name:fra_x_preferred":[
         "Mongu"
     ],
     "name:frr_x_preferred":[
         "Mongu"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d5\u05e0\u05d2\u05d5"
     ],
     "name:hin_x_preferred":[
         "\u092e\u094b\u0902\u0917\u0941"
@@ -104,6 +116,9 @@
     "name:spa_x_preferred":[
         "Mongu"
     ],
+    "name:swa_x_preferred":[
+        "Mongu"
+    ],
     "name:swe_x_preferred":[
         "Mongu"
     ],
@@ -124,6 +139,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8292\u53e4"
+    ],
+    "name:zul_x_preferred":[
+        "Mongu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Zambia",
@@ -266,7 +284,7 @@
         }
     ],
     "wof:id":421201997,
-    "wof:lastmodified":1636501938,
+    "wof:lastmodified":1690930112,
     "wof:name":"Mongu",
     "wof:parent_id":1108782503,
     "wof:placetype":"locality",

--- a/data/421/205/155/421205155.geojson
+++ b/data/421/205/155/421205155.geojson
@@ -50,8 +50,14 @@
     "name:spa_x_preferred":[
         "Sinazongwe"
     ],
+    "name:swa_x_preferred":[
+        "Sinazongwe"
+    ],
     "name:zho_x_preferred":[
         "\u5e0c\u7d0d\u5b97\u683c\u97cb"
+    ],
+    "name:zul_x_preferred":[
+        "Sinazongwe"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -100,7 +106,7 @@
         }
     ],
     "wof:id":421205155,
-    "wof:lastmodified":1566665955,
+    "wof:lastmodified":1690930108,
     "wof:name":"Sinazongwe",
     "wof:parent_id":1108782493,
     "wof:placetype":"locality",

--- a/data/421/205/159/421205159.geojson
+++ b/data/421/205/159/421205159.geojson
@@ -32,6 +32,9 @@
     "name:fra_x_preferred":[
         "Serenje"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05e8\u05e0\u05d6'\u05d4"
+    ],
     "name:ita_x_preferred":[
         "Serenje"
     ],
@@ -61,6 +64,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u4f26\u6770"
+    ],
+    "name:zul_x_preferred":[
+        "Serenje"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":421205159,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930108,
     "wof:name":"Serenje",
     "wof:parent_id":1108782361,
     "wof:placetype":"locality",

--- a/data/421/205/255/421205255.geojson
+++ b/data/421/205/255/421205255.geojson
@@ -56,8 +56,14 @@
     "name:spa_x_preferred":[
         "Petauke"
     ],
+    "name:swa_x_preferred":[
+        "Petauke"
+    ],
     "name:zho_x_preferred":[
         "\u4f69\u9676\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Petauke"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":421205255,
-    "wof:lastmodified":1566665955,
+    "wof:lastmodified":1690930109,
     "wof:name":"Petauke",
     "wof:parent_id":1108782397,
     "wof:placetype":"locality",

--- a/data/421/205/435/421205435.geojson
+++ b/data/421/205/435/421205435.geojson
@@ -56,6 +56,9 @@
     "name:zho_x_preferred":[
         "\u59c6\u6ce2\u6d1b\u79d1\u7d22"
     ],
+    "name:zul_x_preferred":[
+        "Mporokoso"
+    ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":175967,
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421205435,
-    "wof:lastmodified":1566665955,
+    "wof:lastmodified":1690930108,
     "wof:name":"Mporokoso",
     "wof:parent_id":1108782467,
     "wof:placetype":"locality",

--- a/data/421/205/439/421205439.geojson
+++ b/data/421/205/439/421205439.geojson
@@ -32,8 +32,14 @@
     "name:eng_x_preferred":[
         "Mpulungu"
     ],
+    "name:fin_x_preferred":[
+        "Mpulungu"
+    ],
     "name:fra_x_preferred":[
         "Mpulungu"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e4\u05d5\u05dc\u05d5\u05e0\u05d2\u05d5"
     ],
     "name:ita_x_preferred":[
         "Mpulungu"
@@ -45,6 +51,9 @@
         "\u041c\u043f\u0443\u043b\u0443\u043d\u0433\u0443"
     ],
     "name:nld_x_preferred":[
+        "Mpulungu"
+    ],
+    "name:nno_x_preferred":[
         "Mpulungu"
     ],
     "name:pol_x_preferred":[
@@ -61,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u666e\u9686\u53e4"
+    ],
+    "name:zul_x_preferred":[
+        "Mpulungu"
     ],
     "qs:gn_country":"ZM",
     "qs:gn_fcode":"PPL",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421205439,
-    "wof:lastmodified":1566665954,
+    "wof:lastmodified":1690930108,
     "wof:name":"Mpulungu",
     "wof:parent_id":1108782469,
     "wof:placetype":"locality",

--- a/data/890/427/539/890427539.geojson
+++ b/data/890/427/539/890427539.geojson
@@ -40,6 +40,9 @@
     "name:ceb_x_preferred":[
         "Siavonga District"
     ],
+    "name:deu_x_preferred":[
+        "Siavonga"
+    ],
     "name:eng_x_preferred":[
         "Siavonga"
     ],
@@ -58,6 +61,9 @@
     "name:mrj_x_preferred":[
         "\u0421\u0438\u0430\u0432\u043e\u043d\u0433\u0430"
     ],
+    "name:nan_x_preferred":[
+        "Siavonga Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Siavonga District"
     ],
@@ -66,6 +72,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e0c\u4e9e\u8c50\u52a0\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Siavonga District"
     ],
     "qs:name":"Siavonga District",
     "qs:photos_9r":0,
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":890427539,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1690930117,
     "wof:name":"Siavonga",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/890/441/279/890441279.geojson
+++ b/data/890/441/279/890441279.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Chongwe District"
     ],
+    "name:deu_x_preferred":[
+        "Chongwe"
+    ],
     "name:eng_x_preferred":[
         "Chongwe District"
     ],
@@ -34,6 +37,12 @@
     "name:lit_x_preferred":[
         "\u010congv\u0117s apskritis"
     ],
+    "name:mrj_x_preferred":[
+        "\u0427\u043e\u043d\u0433\u0432\u0435"
+    ],
+    "name:nan_x_preferred":[
+        "Chongwe Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Chongwe District"
     ],
@@ -42,6 +51,9 @@
     ],
     "name:zho_x_preferred":[
         "\u74ca\u6208\u97cb\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Chongwe District"
     ],
     "qs:name":"Chongwe",
     "qs:photos_9r":0,
@@ -76,7 +88,7 @@
         }
     ],
     "wof:id":890441279,
-    "wof:lastmodified":1566665962,
+    "wof:lastmodified":1690930117,
     "wof:name":"Chongwe",
     "wof:parent_id":1108782415,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.