### PR TITLE
zm concordances, placetype local, and more

### DIFF
--- a/data/110/878/234/9/1108782349.geojson
+++ b/data/110/878/234/9/1108782349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.189067,
-    "geom:area_square_m":14213822902.416691,
+    "geom:area_square_m":14213822605.667686,
     "geom:bbox":"27.164378,-15.364705,29.008715,-14.336868",
     "geom:latitude":-14.81981,
     "geom:longitude":28.052164,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743457,
-    "wof:geomhash":"93acb8ca6afbf6fb3d742866498ccc6f",
+    "wof:geomhash":"2e914335ddada5434b4243ddf0a8aa30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782349,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886238,
     "wof:name":"Chibombo",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/235/3/1108782353.geojson
+++ b/data/110/878/235/3/1108782353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13018,
-    "geom:area_square_m":1558613576.446062,
+    "geom:area_square_m":1558613988.113849,
     "geom:bbox":"28.125387,-14.697854,28.628131,-14.238872",
     "geom:latitude":-14.472742,
     "geom:longitude":28.385591,
@@ -186,9 +186,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743458,
-    "wof:geomhash":"286472e8ff1bf209c76fe04440548251",
+    "wof:geomhash":"021e63aa3a2153c97b34e080e6f191b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":1108782353,
-    "wof:lastmodified":1636501927,
+    "wof:lastmodified":1695886805,
     "wof:name":"Kabwe",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/235/5/1108782355.geojson
+++ b/data/110/878/235/5/1108782355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.957683,
-    "geom:area_square_m":11486289199.898886,
+    "geom:area_square_m":11486289664.671679,
     "geom:bbox":"26.841944,-14.537841,28.737164,-13.655526",
     "geom:latitude":-14.076463,
     "geom:longitude":27.773958,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743465,
-    "wof:geomhash":"207aef042aaa9e68a1b940f2ca14f04d",
+    "wof:geomhash":"59a93b83bef5f315a81510063d2b95aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782355,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886239,
     "wof:name":"Kapiri mposhi",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/235/7/1108782357.geojson
+++ b/data/110/878/235/7/1108782357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.885077,
-    "geom:area_square_m":22603755696.496708,
+    "geom:area_square_m":22603755550.23901,
     "geom:bbox":"28.590231,-14.995154,30.311772,-13.203669",
     "geom:latitude":-14.127878,
     "geom:longitude":29.389576,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743466,
-    "wof:geomhash":"fcbc21bb92b4e190be7270502256a1b0",
+    "wof:geomhash":"75e4599066abc3f1614543e546aa34d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108782357,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886240,
     "wof:name":"Mkushi",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/235/9/1108782359.geojson
+++ b/data/110/878/235/9/1108782359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.808393,
-    "geom:area_square_m":21598991820.454292,
+    "geom:area_square_m":21598992205.717464,
     "geom:bbox":"25.31998,-15.747307,27.97275,-14.181802",
     "geom:latitude":-14.999151,
     "geom:longitude":26.635179,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743467,
-    "wof:geomhash":"cc12195b073ed24e48f668997224d729",
+    "wof:geomhash":"36cc75db5ddbb4e48e676f8ff308ef92",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108782359,
-    "wof:lastmodified":1636501927,
+    "wof:lastmodified":1695886805,
     "wof:name":"Mumbwa",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/236/1/1108782361.geojson
+++ b/data/110/878/236/1/1108782361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.968926,
-    "geom:area_square_m":23708274220.393139,
+    "geom:area_square_m":23708274220.393654,
     "geom:bbox":"29.7998935146,-13.9340034908,31.4482730115,-12.0004016729",
     "geom:latitude":-13.136742,
     "geom:longitude":30.454717,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CE.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743468,
-    "wof:geomhash":"fe77cc4b638041da2a803a3a849a7765",
+    "wof:geomhash":"c16a25e558883cf865c1892ae700475c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108782361,
-    "wof:lastmodified":1566665699,
+    "wof:lastmodified":1695886574,
     "wof:name":"Serenje",
     "wof:parent_id":85681059,
     "wof:placetype":"county",

--- a/data/110/878/236/3/1108782363.geojson
+++ b/data/110/878/236/3/1108782363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07534,
-    "geom:area_square_m":909925268.737725,
+    "geom:area_square_m":909925450.672048,
     "geom:bbox":"27.660457,-12.538372,28.140541,-12.221684",
     "geom:latitude":-12.380097,
     "geom:longitude":27.89898,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743469,
-    "wof:geomhash":"f2d99548425b37fc7a412676f3da5f68",
+    "wof:geomhash":"acbe1d5f4857229d56bf8816ea068ad1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108782363,
-    "wof:lastmodified":1636501930,
+    "wof:lastmodified":1695886039,
     "wof:name":"Chililabombwe",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/236/5/1108782365.geojson
+++ b/data/110/878/236/5/1108782365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129424,
-    "geom:area_square_m":1562434105.452313,
+    "geom:area_square_m":1562433622.063548,
     "geom:bbox":"27.302112,-12.710351,28.117013,-12.264591",
     "geom:latitude":-12.497193,
     "geom:longitude":27.70934,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743470,
-    "wof:geomhash":"25de308149982d2398f8d90374333fad",
+    "wof:geomhash":"fa3f0855dd32b207d0a963deca59eb2d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108782365,
-    "wof:lastmodified":1636501930,
+    "wof:lastmodified":1695886039,
     "wof:name":"Chingola",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/236/7/1108782367.geojson
+++ b/data/110/878/236/7/1108782367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089812,
-    "geom:area_square_m":1083122630.17205,
+    "geom:area_square_m":1083122630.172033,
     "geom:bbox":"27.7311019512,-12.9025374885,28.1515905025,-12.5626803075",
     "geom:latitude":-12.757096,
     "geom:longitude":27.940252,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743471,
-    "wof:geomhash":"af68b61cc72649f5645b2b8e04a39fb2",
+    "wof:geomhash":"a61e8429d48ead154fc59677efc9bbf8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108782367,
-    "wof:lastmodified":1566665699,
+    "wof:lastmodified":1695886574,
     "wof:name":"Kalulushi",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/237/1/1108782371.geojson
+++ b/data/110/878/237/1/1108782371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101537,
-    "geom:area_square_m":1224405089.179084,
+    "geom:area_square_m":1224405089.179081,
     "geom:bbox":"28.077334604,-13.0160717851,28.534695,-12.5735861644",
     "geom:latitude":-12.781907,
     "geom:longitude":28.276637,
@@ -183,9 +183,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743472,
-    "wof:geomhash":"71f870444d9bee4f0f4f0be8625bb469",
+    "wof:geomhash":"fd24aad35a749b5aca24f61ec99b7e55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":1108782371,
-    "wof:lastmodified":1566665703,
+    "wof:lastmodified":1695886575,
     "wof:name":"Kitwe",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/237/3/1108782373.geojson
+++ b/data/110/878/237/3/1108782373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053837,
-    "geom:area_square_m":648391142.314728,
+    "geom:area_square_m":648390992.06047,
     "geom:bbox":"28.218998,-13.240691,28.564928,-12.911892",
     "geom:latitude":-13.095763,
     "geom:longitude":28.382381,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743473,
-    "wof:geomhash":"5def015edb76a239d1045c6a0464ad88",
+    "wof:geomhash":"305ff395eb557e9c74d6044b96577dcb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108782373,
-    "wof:lastmodified":1636501931,
+    "wof:lastmodified":1695886040,
     "wof:name":"Luanshya",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/237/5/1108782375.geojson
+++ b/data/110/878/237/5/1108782375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.901025,
-    "geom:area_square_m":10857386911.137684,
+    "geom:area_square_m":10857387463.333275,
     "geom:bbox":"26.866335,-13.522405,28.21397,-12.34365",
     "geom:latitude":-12.960895,
     "geom:longitude":27.486533,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.LF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743474,
-    "wof:geomhash":"0cddf2d8bc497aa27027b02bbf9af2d5",
+    "wof:geomhash":"5daa57b825db8dd8500cded3979d648a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108782375,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Lufwanyama",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/237/7/1108782377.geojson
+++ b/data/110/878/237/7/1108782377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3133,
-    "geom:area_square_m":3768781439.498983,
+    "geom:area_square_m":3768780817.580741,
     "geom:bbox":"28.158013,-13.870805,29.058141,-12.833458",
     "geom:latitude":-13.383413,
     "geom:longitude":28.65222,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743475,
-    "wof:geomhash":"564068b29b5e6ed2a729f2cde117d0f8",
+    "wof:geomhash":"709ea5782234fdd2a736a8bb944bac68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782377,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886241,
     "wof:name":"Masaiti",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/237/9/1108782379.geojson
+++ b/data/110/878/237/9/1108782379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.743874,
-    "geom:area_square_m":8940952389.544697,
+    "geom:area_square_m":8940951934.06798,
     "geom:bbox":"26.775536,-13.934093,28.525316,-13.17828",
     "geom:latitude":-13.580255,
     "geom:longitude":27.742782,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743476,
-    "wof:geomhash":"d6a0e9e43ab9a0fd29d47c537a11611d",
+    "wof:geomhash":"2c129818f06f5af6b87fe9ca0c97c507",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782379,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886241,
     "wof:name":"Mpongwe",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/238/1/1108782381.geojson
+++ b/data/110/878/238/1/1108782381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06753,
-    "geom:area_square_m":815102016.056894,
+    "geom:area_square_m":815102086.245998,
     "geom:bbox":"28.082002,-12.697156,28.467153,-12.377714",
     "geom:latitude":-12.539009,
     "geom:longitude":28.257693,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743477,
-    "wof:geomhash":"aff9fc0a6fe553a209b069de8bec3bbf",
+    "wof:geomhash":"948e133026f71a1be826983f2d20becb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108782381,
-    "wof:lastmodified":1636501930,
+    "wof:lastmodified":1695886039,
     "wof:name":"Mufulira",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/238/3/1108782383.geojson
+++ b/data/110/878/238/3/1108782383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106356,
-    "geom:area_square_m":1281559018.434607,
+    "geom:area_square_m":1281559018.434528,
     "geom:bbox":"28.3080993357,-13.1790629098,28.7729751016,-12.7500537905",
     "geom:latitude":-12.969363,
     "geom:longitude":28.547016,
@@ -195,9 +195,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.CO.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743478,
-    "wof:geomhash":"6ddc12a59c847b4e5311c7bff60fee03",
+    "wof:geomhash":"f0e22c0f0588e3f553e571065e719054",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":1108782383,
-    "wof:lastmodified":1566665700,
+    "wof:lastmodified":1695886574,
     "wof:name":"Ndola",
     "wof:parent_id":85681063,
     "wof:placetype":"county",

--- a/data/110/878/238/5/1108782385.geojson
+++ b/data/110/878/238/5/1108782385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208452,
-    "geom:area_square_m":2500289038.667929,
+    "geom:area_square_m":2500289217.523288,
     "geom:bbox":"32.180954,-14.308397,33.241223,-13.786415",
     "geom:latitude":-14.062861,
     "geom:longitude":32.630321,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.CD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743479,
-    "wof:geomhash":"23cb4c5d3b9690b8742a35ac37756c45",
+    "wof:geomhash":"0084b7ff5259b6fb55d9dabc24fe6b2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782385,
-    "wof:lastmodified":1627523016,
+    "wof:lastmodified":1695886238,
     "wof:name":"Chadiza",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/238/9/1108782389.geojson
+++ b/data/110/878/238/9/1108782389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318581,
-    "geom:area_square_m":3820722147.90548,
+    "geom:area_square_m":3820722104.022163,
     "geom:bbox":"31.493461,-14.412268,32.320765,-13.72505",
     "geom:latitude":-14.093715,
     "geom:longitude":31.946058,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743480,
-    "wof:geomhash":"09534186d099add4c97fde7ee6919f78",
+    "wof:geomhash":"7bdacd93eacc503fe531b1b5406479df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782389,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Katete",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/239/1/1108782391.geojson
+++ b/data/110/878/239/1/1108782391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.659187,
-    "geom:area_square_m":20003227669.171265,
+    "geom:area_square_m":20003227472.419147,
     "geom:bbox":"31.970041,-13.995607,33.5475,-11.574436",
     "geom:latitude":-12.826013,
     "geom:longitude":32.682029,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743481,
-    "wof:geomhash":"638af4abc5fbbec4d8732f8cf112e2c7",
+    "wof:geomhash":"95ebf33ade84048aeacc56c1da44594c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108782391,
-    "wof:lastmodified":1636501930,
+    "wof:lastmodified":1695886040,
     "wof:name":"Lundazi",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/239/3/1108782393.geojson
+++ b/data/110/878/239/3/1108782393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.495224,
-    "geom:area_square_m":5958249413.355504,
+    "geom:area_square_m":5958249413.355901,
     "geom:bbox":"31.5454852544,-13.8106031068,32.4648354232,-12.8852218738",
     "geom:latitude":-13.340919,
     "geom:longitude":31.990087,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743482,
-    "wof:geomhash":"22273211d48f1fa8a06c259f60baf00b",
+    "wof:geomhash":"0decf27dd45129bb7bb8eda283c9b574",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108782393,
-    "wof:lastmodified":1566665702,
+    "wof:lastmodified":1695886575,
     "wof:name":"Mambwe",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/239/5/1108782395.geojson
+++ b/data/110/878/239/5/1108782395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.863316,
-    "geom:area_square_m":10340512834.037567,
+    "geom:area_square_m":10340513222.192072,
     "geom:bbox":"29.985712,-14.9961,31.215731,-13.779098",
     "geom:latitude":-14.379737,
     "geom:longitude":30.581171,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743483,
-    "wof:geomhash":"e09a2b536de247109279da3fc2f9e429",
+    "wof:geomhash":"b901e644bbdfa4c6dbec73cb1dfe57b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108782395,
-    "wof:lastmodified":1636501931,
+    "wof:lastmodified":1695886040,
     "wof:name":"Nyimba",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/239/7/1108782397.geojson
+++ b/data/110/878/239/7/1108782397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.732254,
-    "geom:area_square_m":8780583674.692608,
+    "geom:area_square_m":8780583960.728987,
     "geom:bbox":"30.882548,-14.7694,31.959394,-13.413154",
     "geom:latitude":-14.124094,
     "geom:longitude":31.398433,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.ES.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743484,
-    "wof:geomhash":"8cad0e3d37f30c2e23fa9a7713f7f919",
+    "wof:geomhash":"cb65a01e8bef63bf0f6c3d51e0812a9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108782397,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1695886242,
     "wof:name":"Petauke",
     "wof:parent_id":85681065,
     "wof:placetype":"county",

--- a/data/110/878/239/9/1108782399.geojson
+++ b/data/110/878/239/9/1108782399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302081,
-    "geom:area_square_m":3692035288.657193,
+    "geom:area_square_m":3692035074.423873,
     "geom:bbox":"28.693488,-9.143672,29.551093,-8.380775",
     "geom:latitude":-8.72618,
     "geom:longitude":29.132984,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743485,
-    "wof:geomhash":"6556de33523a3bda49d96d2f771714cc",
+    "wof:geomhash":"616a03282dfeb902ad5256d5bfe74035",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108782399,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886238,
     "wof:name":"Chiengi",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/240/1/1108782401.geojson
+++ b/data/110/878/240/1/1108782401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.753256,
-    "geom:area_square_m":9177327279.643705,
+    "geom:area_square_m":9177327883.089138,
     "geom:bbox":"28.621936,-10.306839,29.926633,-9.218128",
     "geom:latitude":-9.830535,
     "geom:longitude":29.292651,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743486,
-    "wof:geomhash":"4b23c53f17ceb5e0217dc438efb26003",
+    "wof:geomhash":"68804a71aa94249bae2b5415a58c08fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108782401,
-    "wof:lastmodified":1636501929,
+    "wof:lastmodified":1695886805,
     "wof:name":"Kawambwa",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/240/3/1108782403.geojson
+++ b/data/110/878/240/3/1108782403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.811235,
-    "geom:area_square_m":9835474305.325666,
+    "geom:area_square_m":9835474839.354742,
     "geom:bbox":"28.384785,-11.990405,29.593069,-10.655265",
     "geom:latitude":-11.329681,
     "geom:longitude":28.894831,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743487,
-    "wof:geomhash":"0ba8f7283c44d8b598770ff1932fc03d",
+    "wof:geomhash":"ba01f318fc43f28c35b50549e45754a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108782403,
-    "wof:lastmodified":1636501929,
+    "wof:lastmodified":1695886806,
     "wof:name":"Mansa",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/240/7/1108782407.geojson
+++ b/data/110/878/240/7/1108782407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.517616,
-    "geom:area_square_m":6261889445.981977,
+    "geom:area_square_m":6261888640.217937,
     "geom:bbox":"28.756309,-12.460163,29.567659,-11.404129",
     "geom:latitude":-11.939978,
     "geom:longitude":29.181385,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743488,
-    "wof:geomhash":"d94c061d3e8dc1b9d264a03ea79e727f",
+    "wof:geomhash":"c9d1f3725d8fcaa1e66a241239632e62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108782407,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886241,
     "wof:name":"Milenge",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/240/9/1108782409.geojson
+++ b/data/110/878/240/9/1108782409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54678,
-    "geom:area_square_m":6648730822.448302,
+    "geom:area_square_m":6648730879.367895,
     "geom:bbox":"28.541903,-11.04373,29.530293,-10.027718",
     "geom:latitude":-10.455406,
     "geom:longitude":28.995377,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743489,
-    "wof:geomhash":"5af98b6727f162e9e06023a8805f4305",
+    "wof:geomhash":"d40add7dda26944b025c489b118058bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782409,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1695886242,
     "wof:name":"Mwense",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/241/1/1108782411.geojson
+++ b/data/110/878/241/1/1108782411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333567,
-    "geom:area_square_m":4069856434.828743,
+    "geom:area_square_m":4069856514.091112,
     "geom:bbox":"28.38008,-9.771183,29.32791,-9.026814",
     "geom:latitude":-9.345121,
     "geom:longitude":28.79807,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743490,
-    "wof:geomhash":"80cfbc55ec488c7378308fa5b4c0f77f",
+    "wof:geomhash":"d147df8827c120f3d2b81e2f7a1aaf93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108782411,
-    "wof:lastmodified":1636501928,
+    "wof:lastmodified":1695886805,
     "wof:name":"Nchelenge",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/241/3/1108782413.geojson
+++ b/data/110/878/241/3/1108782413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.825588,
-    "geom:area_square_m":10004258015.795837,
+    "geom:area_square_m":10004258015.795851,
     "geom:bbox":"29.3654418742,-12.234425,30.4639486626,-10.7051577041",
     "geom:latitude":-11.476526,
     "geom:longitude":29.809416,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LP.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743491,
-    "wof:geomhash":"415edb1cf085be701336e75a9242df48",
+    "wof:geomhash":"000dcb441651548dfc9ebdfddb590d8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108782413,
-    "wof:lastmodified":1566665693,
+    "wof:lastmodified":1695886574,
     "wof:name":"Samfya",
     "wof:parent_id":85681047,
     "wof:placetype":"county",

--- a/data/110/878/241/5/1108782415.geojson
+++ b/data/110/878/241/5/1108782415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.991367,
-    "geom:area_square_m":11829680395.2736,
+    "geom:area_square_m":11829680303.051088,
     "geom:bbox":"28.321774,-15.691358,30.223934,-14.644219",
     "geom:latitude":-15.196965,
     "geom:longitude":29.341575,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LS.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743492,
-    "wof:geomhash":"8d83be26357c35de37e715eca173ee1d",
+    "wof:geomhash":"1bb718bb51c507fec38d7ad127ea7fa6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782415,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886238,
     "wof:name":"Chongwe",
     "wof:parent_id":85681073,
     "wof:placetype":"county",

--- a/data/110/878/241/7/1108782417.geojson
+++ b/data/110/878/241/7/1108782417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501777,
-    "geom:area_square_m":5974208219.040463,
+    "geom:area_square_m":5974207960.456205,
     "geom:bbox":"27.793101,-15.971299,29.345212,-15.256356",
     "geom:latitude":-15.661044,
     "geom:longitude":28.509022,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LS.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743493,
-    "wof:geomhash":"da019458f96a7a6e2032bb6bdc109f2f",
+    "wof:geomhash":"722f956e6ab0ef9829da6852e412899f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108782417,
-    "wof:lastmodified":1636501928,
+    "wof:lastmodified":1695886805,
     "wof:name":"Kafue",
     "wof:parent_id":85681073,
     "wof:placetype":"county",

--- a/data/110/878/241/9/1108782419.geojson
+++ b/data/110/878/241/9/1108782419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322755,
-    "geom:area_square_m":3846945905.934502,
+    "geom:area_square_m":3846946307.156354,
     "geom:bbox":"29.326389,-15.723612,30.421836,-14.997543",
     "geom:latitude":-15.436732,
     "geom:longitude":30.005771,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.LS.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743494,
-    "wof:geomhash":"8e8f3f29c6d25098621161857fc94a5b",
+    "wof:geomhash":"00bcea277b23402538871f2c3556180b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108782419,
-    "wof:lastmodified":1636501928,
+    "wof:lastmodified":1695886805,
     "wof:name":"Luangwa",
     "wof:parent_id":85681073,
     "wof:placetype":"county",

--- a/data/110/878/242/1/1108782421.geojson
+++ b/data/110/878/242/1/1108782421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036982,
-    "geom:area_square_m":440767940.295545,
+    "geom:area_square_m":440767940.29562,
     "geom:bbox":"28.207662,-15.576061,28.495144,-15.334687",
     "geom:latitude":-15.448999,
     "geom:longitude":28.319412,
@@ -435,12 +435,13 @@
     "wof:concordances":{
         "hasc:id":"ZM.LS.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421178937
     ],
     "wof:country":"ZM",
     "wof:created":1481743495,
-    "wof:geomhash":"9cd20b420c3afab8167454f7d56e1b39",
+    "wof:geomhash":"88f16d4a3b9bb42ab1d2abe57002cc02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -450,7 +451,7 @@
         }
     ],
     "wof:id":1108782421,
-    "wof:lastmodified":1636501925,
+    "wof:lastmodified":1695886803,
     "wof:name":"Lusaka",
     "wof:parent_id":85681073,
     "wof:placetype":"county",

--- a/data/110/878/242/5/1108782425.geojson
+++ b/data/110/878/242/5/1108782425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.464244,
-    "geom:area_square_m":17760239706.16954,
+    "geom:area_square_m":17760239838.256233,
     "geom:bbox":"32.220877,-12.180229,33.698877,-10.330821",
     "geom:latitude":-11.200386,
     "geom:longitude":32.804567,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743496,
-    "wof:geomhash":"317db78521b44d11d7bcb981f7ba02d7",
+    "wof:geomhash":"e7371814e7a23317cb8ab28566d1c709",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108782425,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886239,
     "wof:name":"Chama",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/242/7/1108782427.geojson
+++ b/data/110/878/242/7/1108782427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.273212,
-    "geom:area_square_m":15467352434.559988,
+    "geom:area_square_m":15467352522.076178,
     "geom:bbox":"31.104135,-11.647494,32.583344,-9.742214",
     "geom:latitude":-10.739382,
     "geom:longitude":31.910815,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743497,
-    "wof:geomhash":"2db40a347e82388bdd0588f69fee102e",
+    "wof:geomhash":"be31fe02e91e60e97ac51741a92004a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108782427,
-    "wof:lastmodified":1636501925,
+    "wof:lastmodified":1695886803,
     "wof:name":"Chinsali",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/242/9/1108782429.geojson
+++ b/data/110/878/242/9/1108782429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.441843,
-    "geom:area_square_m":5380479176.808417,
+    "geom:area_square_m":5380479031.539064,
     "geom:bbox":"32.439994,-10.441562,33.390278,-9.586667",
     "geom:latitude":-9.997374,
     "geom:longitude":32.84762,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.IO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743498,
-    "wof:geomhash":"f06ebbedac982106b260a14dff8f377e",
+    "wof:geomhash":"13419fc710d9f4894371f9c94e304d30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108782429,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Isoka",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/243/1/1108782431.geojson
+++ b/data/110/878/243/1/1108782431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340178,
-    "geom:area_square_m":4137840888.760027,
+    "geom:area_square_m":4137840899.349854,
     "geom:bbox":"32.995589,-10.796338,33.702222,-9.875444",
     "geom:latitude":-10.354354,
     "geom:longitude":33.327135,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743499,
-    "wof:geomhash":"1dc82b448111e001b5ffdf3826ec8e19",
+    "wof:geomhash":"802728f85471ec45f99fdd5e56743c84",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782431,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886241,
     "wof:name":"Mafinga",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/243/3/1108782433.geojson
+++ b/data/110/878/243/3/1108782433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.327565,
-    "geom:area_square_m":40232618220.203972,
+    "geom:area_square_m":40232617512.876823,
     "geom:bbox":"29.789597,-13.421058,32.579558,-10.919698",
     "geom:latitude":-12.084132,
     "geom:longitude":31.310665,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743500,
-    "wof:geomhash":"e7495846e4777a5652eb5407d707b34a",
+    "wof:geomhash":"5940f09c468405aae21370ac39e69396",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108782433,
-    "wof:lastmodified":1636501925,
+    "wof:lastmodified":1695886804,
     "wof:name":"Mpika",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/243/5/1108782435.geojson
+++ b/data/110/878/243/5/1108782435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.350984,
-    "geom:area_square_m":4280892259.534079,
+    "geom:area_square_m":4280892800.488389,
     "geom:bbox":"32.158672,-9.836835,33.016944,-9.089952",
     "geom:latitude":-9.464871,
     "geom:longitude":32.558887,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.MU.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743501,
-    "wof:geomhash":"dc8602cb96362a864b2c24a7346d63c9",
+    "wof:geomhash":"18cbae946242d40ddeac93a017bcc3a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108782435,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1695886242,
     "wof:name":"Nakonde",
     "wof:parent_id":85681087,
     "wof:placetype":"county",

--- a/data/110/878/243/7/1108782437.geojson
+++ b/data/110/878/243/7/1108782437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379097,
-    "geom:area_square_m":4563257119.887802,
+    "geom:area_square_m":4563257250.289935,
     "geom:bbox":"21.996388,-13.623677,23.022777,-13.0",
     "geom:latitude":-13.225973,
     "geom:longitude":22.388042,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.CV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743502,
-    "wof:geomhash":"7183a273ea72bb6d93541dc98fbfdf52",
+    "wof:geomhash":"ff4fc4516cb1815e8ec3269ce64e8bd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108782437,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886239,
     "wof:name":"Chavuma",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/243/9/1108782439.geojson
+++ b/data/110/878/243/9/1108782439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176097,
-    "geom:area_square_m":2135664961.335814,
+    "geom:area_square_m":2135665179.698472,
     "geom:bbox":"23.994274,-11.592003,24.638813,-10.887828",
     "geom:latitude":-11.24527,
     "geom:longitude":24.242783,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.IG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743503,
-    "wof:geomhash":"86749b8e8e02fb484641170c29b4db57",
+    "wof:geomhash":"8fdfcf99512db45952d07d3eb80cf4cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782439,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886239,
     "wof:name":"Ikelenge",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/244/3/1108782443.geojson
+++ b/data/110/878/244/3/1108782443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.212096,
-    "geom:area_square_m":14587570846.009035,
+    "geom:area_square_m":14587571335.665051,
     "geom:bbox":"23.492852,-14.036672,24.726445,-12.487505",
     "geom:latitude":-13.265003,
     "geom:longitude":24.151666,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743504,
-    "wof:geomhash":"b782b9357b4e30216772b227160d865a",
+    "wof:geomhash":"65f0fcd8e458e25214f0b793c666a5e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108782443,
-    "wof:lastmodified":1636501926,
+    "wof:lastmodified":1695886804,
     "wof:name":"Kabompo",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/244/5/1108782445.geojson
+++ b/data/110/878/244/5/1108782445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.821601,
-    "geom:area_square_m":21884016903.49276,
+    "geom:area_square_m":21884015871.822094,
     "geom:bbox":"25.143977,-14.723357,26.978922,-12.862037",
     "geom:latitude":-13.688464,
     "geom:longitude":26.222516,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743505,
-    "wof:geomhash":"8982343638c4ae9ef4bd963c6c70ae8d",
+    "wof:geomhash":"010222380ae01fd86bad90b100b7da00",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108782445,
-    "wof:lastmodified":1636501926,
+    "wof:lastmodified":1695886804,
     "wof:name":"Kasempa",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/244/7/1108782447.geojson
+++ b/data/110/878/244/7/1108782447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.589081,
-    "geom:area_square_m":19079449625.728172,
+    "geom:area_square_m":19079449857.111515,
     "geom:bbox":"24.345962,-14.625766,26.213107,-12.898144",
     "geom:latitude":-13.825217,
     "geom:longitude":25.229358,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743506,
-    "wof:geomhash":"6ff49f4d21ebe3bf831053ef87ef00af",
+    "wof:geomhash":"9996d25e90469d89241f6c0e9070304a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108782447,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886241,
     "wof:name":"Mufumbwe",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/244/9/1108782449.geojson
+++ b/data/110/878/244/9/1108782449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.559334,
-    "geom:area_square_m":18859928483.240391,
+    "geom:area_square_m":18859927937.373787,
     "geom:bbox":"23.965834,-13.103244,25.474512,-11.188301",
     "geom:latitude":-11.995676,
     "geom:longitude":24.663175,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743507,
-    "wof:geomhash":"4ec05e155fb7ffe6e6c26984d37abae4",
+    "wof:geomhash":"db36f547cd14ab389bd9890d2620c717",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108782449,
-    "wof:lastmodified":1636501926,
+    "wof:lastmodified":1695886804,
     "wof:name":"Mwinilunga",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/245/1/1108782451.geojson
+++ b/data/110/878/245/1/1108782451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.520309,
-    "geom:area_square_m":30434073678.771801,
+    "geom:area_square_m":30434075142.887451,
     "geom:bbox":"24.831812,-13.437877,27.729404,-11.563135",
     "geom:latitude":-12.420847,
     "geom:longitude":26.195155,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743508,
-    "wof:geomhash":"81b12a985f06da1b391e20856eb29d7e",
+    "wof:geomhash":"ad5959e95c5e2ed1800d00baeb9c755e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108782451,
-    "wof:lastmodified":1636501924,
+    "wof:lastmodified":1695886803,
     "wof:name":"Solwezi",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/245/3/1108782453.geojson
+++ b/data/110/878/245/3/1108782453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.189174,
-    "geom:area_square_m":14293709942.761379,
+    "geom:area_square_m":14293709311.982498,
     "geom:bbox":"21.997223,-14.18871,23.71066,-13.0",
     "geom:latitude":-13.570206,
     "geom:longitude":23.040373,
@@ -321,9 +321,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NW.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743510,
-    "wof:geomhash":"a25f29577c1f4ffdccb8784d77cfd0e3",
+    "wof:geomhash":"bac522f7ff4d3382ee0a69632c0f14d6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +334,7 @@
         }
     ],
     "wof:id":1108782453,
-    "wof:lastmodified":1636501925,
+    "wof:lastmodified":1695886804,
     "wof:name":"Zambezi",
     "wof:parent_id":85681075,
     "wof:placetype":"county",

--- a/data/110/878/245/5/1108782455.geojson
+++ b/data/110/878/245/5/1108782455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429209,
-    "geom:area_square_m":5208460309.440941,
+    "geom:area_square_m":5208461225.388554,
     "geom:bbox":"29.816611,-11.491291,30.726934,-10.667315",
     "geom:latitude":-11.070678,
     "geom:longitude":30.261766,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.CI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743511,
-    "wof:geomhash":"1e4e378246d50c0ceec8b454f6074672",
+    "wof:geomhash":"7f2916d7d4640deca86a88e241846414",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108782455,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886239,
     "wof:name":"Chilubi",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/245/7/1108782457.geojson
+++ b/data/110/878/245/7/1108782457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.052688,
-    "geom:area_square_m":12863271244.160156,
+    "geom:area_square_m":12863270529.550316,
     "geom:bbox":"29.099459,-9.342094,30.686427,-8.215838",
     "geom:latitude":-8.800916,
     "geom:longitude":29.90218,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743512,
-    "wof:geomhash":"28d4c03f51424a25c51a85d7a5dd2d6a",
+    "wof:geomhash":"be89feb6caef3ba037d8245023e791bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782457,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Kaputa",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/246/1/1108782461.geojson
+++ b/data/110/878/246/1/1108782461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.875415,
-    "geom:area_square_m":10646675420.916918,
+    "geom:area_square_m":10646674395.668219,
     "geom:bbox":"30.284306,-11.321532,31.536736,-9.731807",
     "geom:latitude":-10.400247,
     "geom:longitude":30.95491,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743513,
-    "wof:geomhash":"29ae587e4872d6e3698587b774e1d30f",
+    "wof:geomhash":"70cdbb919cb6735ada202b07c39e2e9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108782461,
-    "wof:lastmodified":1636501928,
+    "wof:lastmodified":1695886805,
     "wof:name":"Kasama",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/246/3/1108782463.geojson
+++ b/data/110/878/246/3/1108782463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.738126,
-    "geom:area_square_m":8971757155.133844,
+    "geom:area_square_m":8971756420.990917,
     "geom:bbox":"29.092205,-11.100273,30.779328,-10.060158",
     "geom:latitude":-10.582909,
     "geom:longitude":29.960138,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.LW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743514,
-    "wof:geomhash":"aec8e5c307b0d39968380de117a247e3",
+    "wof:geomhash":"79313d6c7e2a108726ec92c46be45a79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782463,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Luwingu",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/246/5/1108782465.geojson
+++ b/data/110/878/246/5/1108782465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.617593,
-    "geom:area_square_m":7538502608.130441,
+    "geom:area_square_m":7538503554.606144,
     "geom:bbox":"30.992441,-9.655769,32.264593,-8.588235",
     "geom:latitude":-9.193323,
     "geom:longitude":31.616845,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743515,
-    "wof:geomhash":"cb11292c087d3c8c3a6bac5d985bdc5c",
+    "wof:geomhash":"8447a97d567b21ea4d2d3b6bb4191ea5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108782465,
-    "wof:lastmodified":1636501929,
+    "wof:lastmodified":1695886806,
     "wof:name":"Mbala",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/246/7/1108782467.geojson
+++ b/data/110/878/246/7/1108782467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.989302,
-    "geom:area_square_m":12058486636.355223,
+    "geom:area_square_m":12058486582.895763,
     "geom:bbox":"29.318874,-10.3193,31.16103,-9.21453",
     "geom:latitude":-9.68403,
     "geom:longitude":30.214228,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743516,
-    "wof:geomhash":"e3655ea90beaf565ba1b1e503d06ad34",
+    "wof:geomhash":"c47e9c7d6d836cdb1fdbe8b8f6ed1b2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782467,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886242,
     "wof:name":"Mporokoso",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/246/9/1108782469.geojson
+++ b/data/110/878/246/9/1108782469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.91939,
-    "geom:area_square_m":11229262118.827398,
+    "geom:area_square_m":11229262118.828142,
     "geom:bbox":"30.2134599276,-9.67442283332,31.4264028344,-8.203284",
     "geom:latitude":-8.968936,
     "geom:longitude":30.818324,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743517,
-    "wof:geomhash":"68854ca7fadadc85eaaabf7b0af761b9",
+    "wof:geomhash":"8d9b5f98de237c3943a7162f62c837ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108782469,
-    "wof:lastmodified":1566665694,
+    "wof:lastmodified":1695886574,
     "wof:name":"Mpulungu",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/247/1/1108782471.geojson
+++ b/data/110/878/247/1/1108782471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.801046,
-    "geom:area_square_m":9757823177.708776,
+    "geom:area_square_m":9757823559.770992,
     "geom:bbox":"31.131553,-10.559753,32.353067,-9.407504",
     "geom:latitude":-9.888985,
     "geom:longitude":31.736157,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.NR.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743518,
-    "wof:geomhash":"c522e28d306c31e237a451c26bb57773",
+    "wof:geomhash":"e82f94b8b512909377172812b24b8938",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782471,
-    "wof:lastmodified":1627523019,
+    "wof:lastmodified":1695886242,
     "wof:name":"Mungwi",
     "wof:parent_id":85681055,
     "wof:placetype":"county",

--- a/data/110/878/247/3/1108782473.geojson
+++ b/data/110/878/247/3/1108782473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.596223,
-    "geom:area_square_m":7059700583.027128,
+    "geom:area_square_m":7059700877.657516,
     "geom:bbox":"26.695416,-17.532829,27.661495,-16.188386",
     "geom:latitude":-16.745431,
     "geom:longitude":27.093461,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743519,
-    "wof:geomhash":"aec06c2a98c3d6b15d22ed97da30d991",
+    "wof:geomhash":"de7ef0c62d821cd9087f398208d632ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108782473,
-    "wof:lastmodified":1636501929,
+    "wof:lastmodified":1695886806,
     "wof:name":"Choma",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/247/5/1108782475.geojson
+++ b/data/110/878/247/5/1108782475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318578,
-    "geom:area_square_m":3773700778.174736,
+    "geom:area_square_m":3773700943.584318,
     "geom:bbox":"27.455848,-16.982631,28.398338,-16.349044",
     "geom:latitude":-16.668727,
     "geom:longitude":27.926794,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743521,
-    "wof:geomhash":"7fa9d5c005affb9896dbd4a45fe1df01",
+    "wof:geomhash":"b267cc55da89304753cdbb4d97ef54e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108782475,
-    "wof:lastmodified":1627523017,
+    "wof:lastmodified":1695886239,
     "wof:name":"Gwembe",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/247/9/1108782479.geojson
+++ b/data/110/878/247/9/1108782479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.366102,
-    "geom:area_square_m":16256700861.005083,
+    "geom:area_square_m":16256700532.780714,
     "geom:bbox":"25.227344,-16.551246,27.277742,-15.27317",
     "geom:latitude":-15.762002,
     "geom:longitude":26.028305,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.IT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743522,
-    "wof:geomhash":"385ce7941eaf310c47ad90540bfec352",
+    "wof:geomhash":"59d94c7e10aca4cba970d63b58e6a6c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108782479,
-    "wof:lastmodified":1627523018,
+    "wof:lastmodified":1695886240,
     "wof:name":"Itezhi tezhi",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/248/1/1108782481.geojson
+++ b/data/110/878/248/1/1108782481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.128931,
-    "geom:area_square_m":13337846733.619143,
+    "geom:area_square_m":13337846733.618288,
     "geom:bbox":"25.9741563694,-18.077418,27.0558085302,-16.293804542",
     "geom:latitude":-17.156732,
     "geom:longitude":26.516888,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743523,
-    "wof:geomhash":"5f7610e9e4caabb8ce1b42c3e552b6dd",
+    "wof:geomhash":"55feef7a0d56fb8eb69e41ff0427552b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782481,
-    "wof:lastmodified":1566665691,
+    "wof:lastmodified":1695886573,
     "wof:name":"Kalomo",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/248/3/1108782483.geojson
+++ b/data/110/878/248/3/1108782483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.560006,
-    "geom:area_square_m":18436313800.49498,
+    "geom:area_square_m":18436313800.49551,
     "geom:bbox":"24.9525419113,-18.002367,26.3813337407,-16.0976545907",
     "geom:latitude":-17.101517,
     "geom:longitude":25.629242,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.KZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743524,
-    "wof:geomhash":"66072ea2aee60134ea794976fb02ca9f",
+    "wof:geomhash":"fa1e42c111785a972ca0faeb400c7273",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108782483,
-    "wof:lastmodified":1566665692,
+    "wof:lastmodified":1695886573,
     "wof:name":"Kazungula",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/248/5/1108782485.geojson
+++ b/data/110/878/248/5/1108782485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074589,
-    "geom:area_square_m":878285447.877456,
+    "geom:area_square_m":878285592.515328,
     "geom:bbox":"25.636409,-17.983913,26.052588,-17.610622",
     "geom:latitude":-17.772884,
     "geom:longitude":25.863209,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743525,
-    "wof:geomhash":"dd4e2775bfb9c84e2cd709f1cdfa9a2a",
+    "wof:geomhash":"041d5532ae7616ff9d66ddcac70ee31e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108782485,
-    "wof:lastmodified":1636501928,
+    "wof:lastmodified":1695886805,
     "wof:name":"Livingstone",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/248/7/1108782487.geojson
+++ b/data/110/878/248/7/1108782487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.56888,
-    "geom:area_square_m":6763145027.513717,
+    "geom:area_square_m":6763145020.7551,
     "geom:bbox":"27.308195,-16.351357,28.607555,-15.485418",
     "geom:latitude":-15.959504,
     "geom:longitude":27.944547,
@@ -142,9 +142,10 @@
         "hasc:id":"ZM.SO.MA",
         "wd:id":"Q964795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743526,
-    "wof:geomhash":"545a444cf5d59a90a3bdddb3ee983d8b",
+    "wof:geomhash":"5a10d178d5bf1fff6dba49e23f6bf505",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108782487,
-    "wof:lastmodified":1690930102,
+    "wof:lastmodified":1695886805,
     "wof:name":"Mazabuka",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/248/9/1108782489.geojson
+++ b/data/110/878/248/9/1108782489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.415362,
-    "geom:area_square_m":4931601378.987632,
+    "geom:area_square_m":4931601378.987378,
     "geom:bbox":"26.9998832954,-16.5383552283,28.1456963814,-15.7201730782",
     "geom:latitude":-16.218793,
     "geom:longitude":27.43637,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743527,
-    "wof:geomhash":"ccec2d17042ab2aa0aa3acfeb8f6523b",
+    "wof:geomhash":"8fc82c73781edda5867f3610d4be09d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108782489,
-    "wof:lastmodified":1566665690,
+    "wof:lastmodified":1695886573,
     "wof:name":"Monze",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/249/1/1108782491.geojson
+++ b/data/110/878/249/1/1108782491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.457802,
-    "geom:area_square_m":5443052763.468518,
+    "geom:area_square_m":5443052763.468685,
     "geom:bbox":"26.3331965376,-16.3481749421,27.2092496005,-15.5801397957",
     "geom:latitude":-15.942845,
     "geom:longitude":26.772825,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743528,
-    "wof:geomhash":"16c0714d0dd4cb3d9285e4b388dbab0b",
+    "wof:geomhash":"a2513de761b7e4d37cefd329a7f85b71",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108782491,
-    "wof:lastmodified":1566665698,
+    "wof:lastmodified":1695886574,
     "wof:name":"Namwala",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/249/3/1108782493.geojson
+++ b/data/110/878/249/3/1108782493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.432266,
-    "geom:area_square_m":5100405797.150223,
+    "geom:area_square_m":5100406114.768185,
     "geom:bbox":"26.720303,-17.994392,27.815752,-16.881353",
     "geom:latitude":-17.393976,
     "geom:longitude":27.291628,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.SO.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743529,
-    "wof:geomhash":"56c0b64446d417ddc02acdea8b97766a",
+    "wof:geomhash":"3918a807fbf239489a03c3b413e912cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108782493,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1695886242,
     "wof:name":"Sinazongwe",
     "wof:parent_id":85681079,
     "wof:placetype":"county",

--- a/data/110/878/249/7/1108782497.geojson
+++ b/data/110/878/249/7/1108782497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.510391,
-    "geom:area_square_m":18035746329.625374,
+    "geom:area_square_m":18035746956.086815,
     "geom:bbox":"21.998889,-16.141491,23.010981,-14.00919",
     "geom:latitude":-15.041004,
     "geom:longitude":22.409078,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743530,
-    "wof:geomhash":"e6fb2c576053cb82f73ca4c9b2d4d6d9",
+    "wof:geomhash":"2159c25ac6aef64c43712992141086cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108782497,
-    "wof:lastmodified":1636501930,
+    "wof:lastmodified":1695886040,
     "wof:name":"Kalabo",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/249/9/1108782499.geojson
+++ b/data/110/878/249/9/1108782499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.944355,
-    "geom:area_square_m":23225191059.430401,
+    "geom:area_square_m":23225191654.880699,
     "geom:bbox":"23.664912,-16.106731,25.597708,-13.962396",
     "geom:latitude":-14.974727,
     "geom:longitude":24.691044,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743531,
-    "wof:geomhash":"f6703cd509e26fb786f8b038f3f9caef",
+    "wof:geomhash":"3be99b58280989c75729559703db33bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108782499,
-    "wof:lastmodified":1636501929,
+    "wof:lastmodified":1695886039,
     "wof:name":"Kaoma",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/250/1/1108782501.geojson
+++ b/data/110/878/250/1/1108782501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.311263,
-    "geom:area_square_m":15714931881.6544,
+    "geom:area_square_m":15714931410.944811,
     "geom:bbox":"21.998055,-14.839515,24.644241,-13.75567",
     "geom:latitude":-14.251131,
     "geom:longitude":23.371121,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.LK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743532,
-    "wof:geomhash":"c1a85a5db04cddc3426b25c03269c13e",
+    "wof:geomhash":"507455c4f3d7927c39724a125c7affc4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108782501,
-    "wof:lastmodified":1636501926,
+    "wof:lastmodified":1695886804,
     "wof:name":"Lukulu",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/250/3/1108782503.geojson
+++ b/data/110/878/250/3/1108782503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.836561,
-    "geom:area_square_m":9980827815.045616,
+    "geom:area_square_m":9980828162.767006,
     "geom:bbox":"22.815246,-15.806646,24.12132,-14.616411",
     "geom:latitude":-15.230326,
     "geom:longitude":23.495411,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743533,
-    "wof:geomhash":"adfc589602368c6ed404325d9c2392c4",
+    "wof:geomhash":"b8211d9d07600321afed74c617cb00d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108782503,
-    "wof:lastmodified":1636501927,
+    "wof:lastmodified":1695886805,
     "wof:name":"Mongu",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/250/5/1108782505.geojson
+++ b/data/110/878/250/5/1108782505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.284836,
-    "geom:area_square_m":15275714193.593225,
+    "geom:area_square_m":15275714885.227884,
     "geom:bbox":"22.545992,-16.691602,24.613171,-15.323318",
     "geom:latitude":-15.945889,
     "geom:longitude":23.574351,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743534,
-    "wof:geomhash":"b10c31d736582ffc00c16cecd65efb37",
+    "wof:geomhash":"7aed113b6e842de7737c73c68683effa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108782505,
-    "wof:lastmodified":1636501927,
+    "wof:lastmodified":1695886805,
     "wof:name":"Senanga",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/250/7/1108782507.geojson
+++ b/data/110/878/250/7/1108782507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.500981,
-    "geom:area_square_m":29612307299.528542,
+    "geom:area_square_m":29612307366.114166,
     "geom:bbox":"23.146168,-17.637868,25.408035,-15.478455",
     "geom:latitude":-16.746669,
     "geom:longitude":24.39503,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743535,
-    "wof:geomhash":"7b1283e3b205de8a1f6c6978fbbb8cbd",
+    "wof:geomhash":"f2c2e1f9d03ac9c07e9ebf1f73164b82",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108782507,
-    "wof:lastmodified":1636501926,
+    "wof:lastmodified":1695886804,
     "wof:name":"Sesheke",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/110/878/250/9/1108782509.geojson
+++ b/data/110/878/250/9/1108782509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.32003,
-    "geom:area_square_m":15644402071.518124,
+    "geom:area_square_m":15644401222.682476,
     "geom:bbox":"22.0,-17.41937,23.711974,-15.80418",
     "geom:latitude":-16.568863,
     "geom:longitude":22.862963,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"ZM.WE.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1481743536,
-    "wof:geomhash":"56a97d68890f6efb0f9d9adda56b0c2e",
+    "wof:geomhash":"cd75fe2bb0715b383e3f8ac107a9237b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108782509,
-    "wof:lastmodified":1627523020,
+    "wof:lastmodified":1695886243,
     "wof:name":"Shangombo",
     "wof:parent_id":85681083,
     "wof:placetype":"county",

--- a/data/856/325/59/85632559.geojson
+++ b/data/856/325/59/85632559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":62.745302,
-    "geom:area_square_m":753957104542.262207,
+    "geom:area_square_m":753957104542.244995,
     "geom:bbox":"21.996388,-18.077418,33.702222,-8.203284",
     "geom:latitude":-13.454028,
     "geom:longitude":27.797599,
@@ -14,6 +14,9 @@
     "iso:country":"ZM",
     "itu:country_code":[
         "260"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "ZM"
@@ -993,7 +996,8 @@
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"260",
     "statoids:ds":"Z",
     "statoids:fifa":"ZAM",
@@ -1053,7 +1057,7 @@
         "naturalearth",
         "naturalearth-display-terrestrial-zoom6"
     ],
-    "wof:geomhash":"a1503a8cf191bdc93cdc548ac82beed9",
+    "wof:geomhash":"e2369ef0f06e58bc43bf7f2c30615fcb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -1067,12 +1071,12 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827567,
+    "wof:lastmodified":1694492092,
     "wof:name":"Zambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",
-    "wof:population":14309466,
-    "wof:population_rank":14,
+    "wof:population":17861030,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-zm",
     "wof:shortcode":"ZM",
     "wof:superseded_by":[],

--- a/data/856/325/59/85632559.geojson
+++ b/data/856/325/59/85632559.geojson
@@ -997,7 +997,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"260",
     "statoids:ds":"Z",
     "statoids:fifa":"ZAM",
@@ -1071,7 +1071,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694492092,
+    "wof:lastmodified":1694639545,
     "wof:name":"Zambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/325/59/85632559.geojson
+++ b/data/856/325/59/85632559.geojson
@@ -1036,6 +1036,7 @@
         "hasc:id":"ZM",
         "icao:code":"9J",
         "ioc:id":"ZAM",
+        "iso:code":"ZM",
         "itu:id":"ZMB",
         "loc:id":"n80089997",
         "m49:code":"894",
@@ -1050,6 +1051,7 @@
         "wk:page":"Zambia",
         "wmo:id":"ZB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:country_alpha3":"ZMB",
     "wof:geom_alt":[
@@ -1071,7 +1073,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639545,
+    "wof:lastmodified":1695881203,
     "wof:name":"Zambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/810/47/85681047.geojson
+++ b/data/856/810/47/85681047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.090123,
-    "geom:area_square_m":49689571592.682152,
+    "geom:area_square_m":49689571839.688393,
     "geom:bbox":"28.38008,-12.460163,30.463949,-8.380775",
     "geom:latitude":-10.689457,
     "geom:longitude":29.212107,
@@ -273,17 +273,19 @@
         "gn:id":909845,
         "gp:id":2347808,
         "hasc:id":"ZM.LP",
+        "iso:code":"ZM-04",
         "iso:id":"ZM-04",
         "qs_pg:id":235670,
         "unlc:id":"ZM-04",
         "wd:id":"Q386667",
         "wk:page":"Luapula Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4717e78257fde9f0d96b110bd6686406",
+    "wof:geomhash":"2becc4574a820d12d8a90b1c8fcad74d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -298,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501914,
+    "wof:lastmodified":1695884920,
     "wof:name":"Luapula",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/55/85681055.geojson
+++ b/data/856/810/55/85681055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.42277,
-    "geom:area_square_m":78274250644.690582,
+    "geom:area_square_m":78274251045.643524,
     "geom:bbox":"29.092205,-11.491291,32.353067,-8.203284",
     "geom:latitude":-9.708889,
     "geom:longitude":30.649173,
@@ -224,17 +224,19 @@
         "gn:id":900601,
         "gp:id":2347807,
         "hasc:id":"ZM.NR",
+        "iso:code":"ZM-05",
         "iso:id":"ZM-05",
         "qs_pg:id":424152,
         "unlc:id":"ZM-05",
         "wd:id":"Q778738",
         "wk:page":"Northern Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c34bfbc1368fd810cfa8abbc63b4d2b",
+    "wof:geomhash":"21375cb60bdb74b0475ed0d0bcb29e32",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -249,7 +251,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501913,
+    "wof:lastmodified":1695884919,
     "wof:name":"Northern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/59/85681059.geojson
+++ b/data/856/810/59/85681059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.939325,
-    "geom:area_square_m":95169747416.107132,
+    "geom:area_square_m":95169748275.1931,
     "geom:bbox":"25.31998,-15.747307,31.448273,-12.000402",
     "geom:latitude":-14.183618,
     "geom:longitude":28.61469,
@@ -291,17 +291,19 @@
         "gn:id":921064,
         "gp:id":2347805,
         "hasc:id":"ZM.CE",
+        "iso:code":"ZM-02",
         "iso:id":"ZM-02",
         "qs_pg:id":424151,
         "unlc:id":"ZM-02",
         "wd:id":"Q190718",
         "wk:page":"Central Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e153589958affc35aab80d0b907505fd",
+    "wof:geomhash":"88a974ea9e1418096f6fbb673a6e6a8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501911,
+    "wof:lastmodified":1695884918,
     "wof:name":"Central",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/63/85681063.geojson
+++ b/data/856/810/63/85681063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.582033,
-    "geom:area_square_m":31092060010.528484,
+    "geom:area_square_m":31092058933.48542,
     "geom:bbox":"26.775536,-13.934093,29.058141,-12.221684",
     "geom:latitude":-13.128408,
     "geom:longitude":27.854385,
@@ -288,17 +288,19 @@
         "gn:id":917524,
         "gp:id":2347802,
         "hasc:id":"ZM.CO",
+        "iso:code":"ZM-08",
         "iso:id":"ZM-08",
         "qs_pg:id":1047842,
         "unlc:id":"ZM-08",
         "wd:id":"Q1131523",
         "wk:page":"Copperbelt Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa9307f1f5a82ea67b4d108df2ef23e3",
+    "wof:geomhash":"8668bc14f28fc3a7bbc581f2766f173f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501913,
+    "wof:lastmodified":1695884919,
     "wof:name":"Copperbelt",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/65/85681065.geojson
+++ b/data/856/810/65/85681065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.277014,
-    "geom:area_square_m":51403584777.829201,
+    "geom:area_square_m":51403585136.200928,
     "geom:bbox":"29.985712,-14.9961,33.5475,-11.574436",
     "geom:latitude":-13.5762,
     "geom:longitude":31.900751,
@@ -285,17 +285,19 @@
         "gn:id":917388,
         "gp:id":2347806,
         "hasc:id":"ZM.ES",
+        "iso:code":"ZM-03",
         "iso:id":"ZM-03",
         "qs_pg:id":1285712,
         "unlc:id":"ZM-03",
         "wd:id":"Q823810",
         "wk:page":"Eastern Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"602d9c73f188130e0e34fec07758cce6",
+    "wof:geomhash":"f9e25df49bec0534517fd7640eb3853a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501912,
+    "wof:lastmodified":1695884918,
     "wof:name":"Eastern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/73/85681073.geojson
+++ b/data/856/810/73/85681073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.852881,
-    "geom:area_square_m":22091602399.411507,
+    "geom:area_square_m":22091602510.958557,
     "geom:bbox":"27.793101,-15.971299,30.421836,-14.644219",
     "geom:latitude":-15.369437,
     "geom:longitude":29.211408,
@@ -273,17 +273,19 @@
         "gn:id":909129,
         "gp:id":2347809,
         "hasc:id":"ZM.LS",
+        "iso:code":"ZM-09",
         "iso:id":"ZM-09",
         "qs_pg:id":235671,
         "unlc:id":"ZM-09",
         "wd:id":"Q819998",
         "wk:page":"Lusaka Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7974d7f3a9380fb566b90a5c2ba34ff4",
+    "wof:geomhash":"ed9da25f656b29cb89e22fdb966f65c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -298,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501912,
+    "wof:lastmodified":1695884918,
     "wof:name":"Lusaka",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/75/85681075.geojson
+++ b/data/856/810/75/85681075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.446788,
-    "geom:area_square_m":125837671561.226578,
+    "geom:area_square_m":125837671886.829468,
     "geom:bbox":"21.996388,-14.723357,27.729404,-10.887828",
     "geom:latitude":-13.030217,
     "geom:longitude":25.057071,
@@ -287,17 +287,19 @@
         "gn:id":900594,
         "gp:id":2347801,
         "hasc:id":"ZM.NW",
+        "iso:code":"ZM-06",
         "iso:id":"ZM-06",
         "qs_pg:id":1047800,
         "unlc:id":"ZM-06",
         "wd:id":"Q846320",
         "wk:page":"North-Western Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f54e1e3a53d95265fbbc182d5be362d6",
+    "wof:geomhash":"e19cc3ff6401d84386ac1f1659f22904",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501912,
+    "wof:lastmodified":1695884919,
     "wof:name":"North-Western",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/79/85681079.geojson
+++ b/data/856/810/79/85681079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.227923,
-    "geom:area_square_m":85650106573.689682,
+    "geom:area_square_m":85650105501.441788,
     "geom:bbox":"24.952542,-18.077418,28.92079,-15.27317",
     "geom:latitude":-16.584841,
     "geom:longitude":26.651602,
@@ -288,6 +288,7 @@
         "gn:id":896972,
         "gp:id":2347804,
         "hasc:id":"ZM.SO",
+        "iso:code":"ZM-07",
         "iso:id":"ZM-07",
         "loc:id":"n83022861",
         "qs_pg:id":895030,
@@ -295,11 +296,12 @@
         "wd:id":"Q738382",
         "wk:page":"Southern Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea4df2dd1b3910055a17a933ed121480",
+    "wof:geomhash":"4d40c2e06b3d0e87fdbb5b53e52fb12a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501913,
+    "wof:lastmodified":1695884919,
     "wof:name":"Southern",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/83/85681083.geojson
+++ b/data/856/810/83/85681083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.708417,
-    "geom:area_square_m":127489120650.399155,
+    "geom:area_square_m":127489121658.70903,
     "geom:bbox":"21.998055,-17.637868,25.597708,-13.75567",
     "geom:latitude":-15.642313,
     "geom:longitude":23.68568,
@@ -294,6 +294,7 @@
         "gn:id":896140,
         "gp:id":2347803,
         "hasc:id":"ZM.WE",
+        "iso:code":"ZM-01",
         "iso:id":"ZM-01",
         "loc:id":"n83055144",
         "qs_pg:id":895029,
@@ -301,11 +302,12 @@
         "wd:id":"Q748486",
         "wk:page":"Western Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7844e069a46354c841d5fdaa59d9e6b5",
+    "wof:geomhash":"8259700153ceee8880ae878d714e06b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501914,
+    "wof:lastmodified":1695884920,
     "wof:name":"Western",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/856/810/87/85681087.geojson
+++ b/data/856/810/87/85681087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.198027,
-    "geom:area_square_m":87259422686.036469,
+    "geom:area_square_m":87259422604.587952,
     "geom:bbox":"29.789597,-13.421058,33.702222,-9.089952",
     "geom:latitude":-11.328933,
     "geom:longitude":31.971223,
@@ -221,17 +221,19 @@
         "gn:id":900601,
         "gp:id":2347807,
         "hasc:id":"ZM.MU",
+        "iso:code":"ZM-10",
         "iso:id":"ZM-10",
         "qs_pg:id":424152,
         "unlc:id":"ZM-10",
         "wd:id":"Q778738",
         "wk:page":"Northern Province, Zambia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d324809179b3f48fc595c241c8a3b490",
+    "wof:geomhash":"fdbdef22638e789f6c9de442e5bb3760",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -246,7 +248,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501912,
+    "wof:lastmodified":1695884919,
     "wof:name":"Muchinga",
     "wof:parent_id":85632559,
     "wof:placetype":"region",

--- a/data/890/427/539/890427539.geojson
+++ b/data/890/427/539/890427539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309185,
-    "geom:area_square_m":3669353402.372021,
+    "geom:area_square_m":3669353138.040057,
     "geom:bbox":"28.150658,-16.664776,28.92079,-15.911158",
     "geom:latitude":-16.304369,
     "geom:longitude":28.572508,
@@ -110,12 +110,13 @@
         "wd:id":"Q3031862",
         "wk:page":"Siavonga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZM",
     "wof:created":1469051701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"79716c731421c5b3d32f7407b88bf729",
+    "wof:geomhash":"954e9ca68b090c76739016a7dd93b136",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":890427539,
-    "wof:lastmodified":1690930117,
+    "wof:lastmodified":1695886242,
     "wof:name":"Siavonga",
     "wof:parent_id":85681079,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.